### PR TITLE
ENH: Species now stores the prefix for stableids

### DIFF
--- a/src/ensembl_lite/data/species.tsv
+++ b/src/ensembl_lite/data/species.tsv
@@ -1,318 +1,318 @@
-species	common name
-Acanthochromis polyacanthus	Spiny chromis
-Accipiter nisus	Eurasian sparrowhawk
-Ailuropoda melanoleuca	Giant panda
-Amazona collaria	Yellow-billed parrot
-Amphilophus citrinellus	Midas cichlid
-Amphiprion ocellaris	Clown anemonefish
-Amphiprion percula	Orange clownfish
-Anabas testudineus	Climbing perch
-Anas platyrhynchos	Mallard
-Anas platyrhynchos platyrhynchos	Duck
-Anas zonorhyncha	Eastern spot-billed duck
-Anolis carolinensis	Green anole
-Anser brachyrhynchus	Pink-footed goose
-Anser cygnoides	Swan goose
-Aotus nancymaae	Ma's night monkey
-Apteryx haastii	Great spotted kiwi
-Apteryx owenii	Little spotted kiwi
-Apteryx rowi	Okarito brown kiwi
-Aquila chrysaetos chrysaetos	Golden eagle
-Astatotilapia calliptera	Eastern happy
-Astyanax mexicanus	Mexican tetra
-Astyanax mexicanus pachon	Pachon cavefish
-Athene cunicularia	Burrowing owl
-Balaenoptera musculus	Blue whale
-Betta splendens	Siamese fighting fish
-Bison bison bison	American bison
-Bos grunniens	Domestic yak
-Bos indicus hybrid	Hybrid - Bos Indicus
-Bos mutus	Wild yak
-Bos taurus	Cow
-Bos taurus hybrid	Hybrid - Bos Taurus
-Bubo bubo	Eurasian eagle-owl
-Buteo japonicus	Eastern buzzard
-Caenorhabditis elegans	Caenorhabditis elegans (PRJNA13758)
-Cairina moschata domestica	Muscovy Duck (domestic type)
-Calidris pugnax	Ruff
-Calidris pygmaea	Spoon-billed sandpiper
-Callithrix jacchus	White-tufted-ear marmoset
-Callorhinchus milii	Elephant shark
-Camarhynchus parvulus	Small tree finch
-Camelus dromedarius	Arabian camel
-Canis lupus dingo	Dingo
-Canis lupus familiaris	Dog
-Canis lupus familiarisbasenji	Dog - Basenji
-Canis lupus familiarisboxer	Dog - Boxer
-Canis lupus familiarisgreatdane	Dog - Great Dane
-Canis lupus familiarisgsd	Dog - German Shepherd
-Capra hircus	Goat
-Capra hircus blackbengal	Goat (black bengal)
-Carassius auratus	Goldfish
-Carlito syrichta	Tarsier
-Castor canadensis	American beaver
-Catagonus wagneri	Chacoan peccary
-Catharus ustulatus	Swainson's thrush
-Cavia aperea	Brazilian guinea pig
-Cavia porcellus	Guinea Pig
-Cebus imitator	Panamanian white-faced capuchin
-Cercocebus atys	Sooty mangabey
-Cervus hanglu yarkandensis	Yarkand deer
-Chelonoidis abingdonii	Abingdon island giant tortoise
-Chelydra serpentina	Common snapping turtle
-Chinchilla lanigera	Long-tailed chinchilla
-Chlorocebus sabaeus	Vervet-AGM
-Choloepus hoffmanni	Sloth
-Chrysemys picta bellii	Painted turtle
-Chrysolophus pictus	Golden pheasant
-Ciona intestinalis	C.intestinalis
-Ciona savignyi	C.savignyi
-Clupea harengus	Atlantic herring
-Colobus angolensis palliatus	Angola colobus
-Corvus moneduloides	New Caledonian crow
-Cottoperca gobio	Channel bull blenny
-Coturnix japonica	Japanese quail
-Cricetulus griseus chok1gshd	Chinese hamster CHOK1GS
-Cricetulus griseus crigri	Chinese hamster CriGri
-Cricetulus griseus picr	Chinese hamster PICR
-Crocodylus porosus	Australian saltwater crocodile
-Cyanistes caeruleus	Blue tit
-Cyclopterus lumpus	Lumpfish
-Cynoglossus semilaevis	Tongue sole
-Cyprinodon variegatus	Sheepshead minnow
-Cyprinus carpio carpio	Common carp
-Cyprinus carpio germanmirror	Common carp german mirror
-Cyprinus carpio hebaored	Common carp hebao red
-Cyprinus carpio huanghe	Common carp huanghe
-Danio rerio	Zebrafish
-Dasypus novemcinctus	Armadillo
-Delphinapterus leucas	Beluga whale
-Denticeps clupeoides	Denticle herring
-Dicentrarchus labrax	European seabass
-Dipodomys ordii	Kangaroo rat
-Dromaius novaehollandiae	Emu
-Drosophila melanogaster	Drosophila melanogaster (Fruit fly)
-Echeneis naucrates	Live sharksucker
-Echinops telfairi	Lesser hedgehog tenrec
-Electrophorus electricus	Electric eel
-Eptatretus burgeri	Hagfish
-Equus asinus	Donkey
-Equus caballus	Horse
-Erinaceus europaeus	Hedgehog
-Erpetoichthys calabaricus	Reedfish
-Erythrura gouldiae	Gouldian finch
-Esox lucius	Northern pike
-Falco tinnunculus	Common kestrel
-Felis catus	Cat
-Ficedula albicollis	Collared flycatcher
-Fukomys damarensis	Damara mole rat
-Fundulus heteroclitus	Mummichog
-Gadus morhua	Atlantic cod
-Gallus gallus	Chicken
-Gallus gallus gca000002315v5	Chicken (Red Jungle fowl)
-Gallus gallus gca016700215v2	Chicken (paternal White leghorn layer)
-Gambusia affinis	Western mosquitofish
-Gasterosteus aculeatus	Stickleback
-Geospiza fortis	Medium ground-finch
-Gopherus agassizii	Agassiz's desert tortoise
-Gopherus evgoodei	Goodes thornscrub tortoise
-Gorilla gorilla	Gorilla
-Gouania willdenowi	Blunt-snouted clingfish
-Haplochromis burtoni	Burton's mouthbrooder
-Heterocephalus glaber female	Naked mole-rat female
-Heterocephalus glaber male	Naked mole-rat male
-Hippocampus comes	Tiger tail seahorse
-Homo sapiens	Human
-Hucho hucho	Huchen
-Ictalurus punctatus	Channel catfish
-Ictidomys tridecemlineatus	Squirrel
-Jaculus jaculus	Lesser Egyptian jerboa
-Junco hyemalis	Dark-eyed junco
-Kryptolebias marmoratus	Mangrove rivulus
-Labrus bergylta	Ballan wrasse
-Larimichthys crocea	Large yellow croaker
-Lates calcarifer	Barramundi perch
-Laticauda laticaudata	Blue-ringed sea krait
-Latimeria chalumnae	Coelacanth
-Lepidothrix coronata	Blue-crowned manakin
-Lepisosteus oculatus	Spotted gar
-Leptobrachium leishanense	Leishan spiny toad
-Lonchura striata domestica	Bengalese finch
-Loxodonta africana	Elephant
-Lynx canadensis	Canada lynx
-Macaca fascicularis	Crab-eating macaque
-Macaca mulatta	Macaque
-Macaca nemestrina	Pig-tailed macaque
-Malurus cyaneus samueli	Superb fairywren
-Manacus vitellinus	Golden-collared manakin
-Mandrillus leucophaeus	Drill
-Marmota marmota marmota	Alpine marmot
-Mastacembelus armatus	Zig-zag eel
-Maylandia zebra	Zebra mbuna
-Meleagris gallopavo	Turkey
-Melopsittacus undulatus	Budgerigar
-Meriones unguiculatus	Mongolian gerbil
-Mesocricetus auratus	Golden Hamster
-Microcebus murinus	Mouse Lemur
-Microtus ochrogaster	Prairie vole
-Mola mola	Ocean sunfish
-Monodelphis domestica	Opossum
-Monodon monoceros	Narwhal
-Monopterus albus	Swamp eel
-Moschus moschiferus	Siberian musk deer
-Mus caroli	Ryukyu mouse
-Mus musculus	Mouse
-Mus musculus 129s1svimj	Mouse 129S1/SvImJ
-Mus musculus aj	Mouse A/J
-Mus musculus akrj	Mouse AKR/J
-Mus musculus balbcj	Mouse BALB/cJ
-Mus musculus c3hhej	Mouse C3H/HeJ
-Mus musculus c57bl6nj	Mouse C57BL/6NJ
-Mus musculus casteij	Mouse CAST/EiJ
-Mus musculus cbaj	Mouse CBA/J
-Mus musculus dba2j	Mouse DBA/2J
-Mus musculus fvbnj	Mouse FVB/NJ
-Mus musculus lpj	Mouse LP/J
-Mus musculus nodshiltj	Mouse NOD/ShiLtJ
-Mus musculus nzohlltj	Mouse NZO/HlLtJ
-Mus musculus pwkphj	Mouse PWK/PhJ
-Mus musculus wsbeij	Mouse WSB/EiJ
-Mus pahari	Shrew mouse
-Mus spicilegus	Steppe mouse
-Mus spretus	Algerian mouse
-Mustela putorius furo	Ferret
-Myotis lucifugus	Microbat
-Myripristis murdjan	Pinecone soldierfish
-Naja naja	Indian cobra
-Nannospalax galili	Upper Galilee mountains blind mole rat
-Neogobius melanostomus	Round goby
-Neolamprologus brichardi	Lyretail cichlid
-Neovison vison	American mink
-Nomascus leucogenys	Gibbon
-Notamacropus eugenii	Wallaby
-Notechis scutatus	Mainland tiger snake
-Nothobranchius furzeri	Turquoise killifish
-Nothoprocta perdicaria	Chilean tinamou
-Numida meleagris	Helmeted guineafowl
-Ochotona princeps	Pika
-Octodon degus	Degu
-Oncorhynchus kisutch	Coho salmon
-Oncorhynchus mykiss	Rainbow trout
-Oncorhynchus tshawytscha	Chinook salmon
-Oreochromis aureus	Blue tilapia
-Oreochromis niloticus	Nile tilapia
-Ornithorhynchus anatinus	Platypus
-Oryctolagus cuniculus	Rabbit
-Oryzias javanicus	Javanese ricefish
-Oryzias latipes	Japanese medaka HdrR
-Oryzias latipes hni	Japanese medaka HNI
-Oryzias latipes hsok	Japanese medaka HSOK
-Oryzias melastigma	Indian medaka
-Oryzias sinensis	Chinese medaka
-Otolemur garnettii	Bushbaby
-Otus sunia	Oriental scops-owl
-Ovis aries	Sheep (texel)
-Ovis aries rambouillet	Sheep
-Pan paniscus	Bonobo
-Pan troglodytes	Chimpanzee
-Panthera leo	Lion
-Panthera pardus	Leopard
-Panthera tigris altaica	Tiger
-Papio anubis	Olive baboon
-Parambassis ranga	Indian glassy fish
-Paramormyrops kingsleyae	Paramormyrops kingsleyae
-Parus major	Great Tit
-Pavo cristatus	Indian peafowl
-Pelodiscus sinensis	Chinese softshell turtle
-Pelusios castaneus	West African mud turtle
-Periophthalmus magnuspinnatus	Periophthalmus magnuspinnatus
-Peromyscus maniculatus bairdii	Northern American deer mouse
-Petromyzon marinus	Lamprey
-Phascolarctos cinereus	Koala
-Phasianus colchicus	Ring-necked pheasant
-Phocoena sinus	Vaquita
-Physeter catodon	Sperm whale
-Piliocolobus tephrosceles	Ugandan red Colobus
-Podarcis muralis	Common wall lizard
-Poecilia formosa	Amazon molly
-Poecilia latipinna	Sailfin molly
-Poecilia mexicana	Shortfin molly
-Poecilia reticulata	Guppy
-Pogona vitticeps	Central bearded dragon
-Pongo abelii	Sumatran orangutan
-Procavia capensis	Hyrax
-Prolemur simus	Greater bamboo lemur
-Propithecus coquereli	Coquerel's sifaka
-Pseudonaja textilis	Eastern brown snake
-Pteropus vampyrus	Megabat
-Pundamilia nyererei	Makobe Island cichlid
-Pygocentrus nattereri	Red-bellied piranha
-Rattus norvegicus	Rat
-Rattus norvegicus shrspbbbutx	Rat - SHRSP/BbbUtx
-Rattus norvegicus shrutx	Rat - SHR/Utx RGD_8142385
-Rattus norvegicus wkybbb	Rat - WKY/Bbb RGD_1581635
-Rhinolophus ferrumequinum	Greater horseshoe bat
-Rhinopithecus bieti	Black snub-nosed monkey
-Rhinopithecus roxellana	Golden snub-nosed monkey
-Saccharomyces cerevisiae	Saccharomyces cerevisiae
-Saimiri boliviensis boliviensis	Bolivian squirrel monkey
-Salarias fasciatus	Jewelled blenny
-Salmo salar	Atlantic salmon
-Salmo trutta	Brown trout
-Salvator merianae	Argentine black and white tegu
-Sander lucioperca	Pike-perch
-Sarcophilus harrisii	Tasmanian devil
-Sciurus vulgaris	Eurasian red squirrel
-Scleropages formosus	Asian bonytongue
-Scophthalmus maximus	Turbot
-Serinus canaria	Common canary
-Seriola dumerili	Greater amberjack
-Seriola lalandi dorsalis	Yellowtail amberjack
-Sinocyclocheilus anshuiensis	Blind barbel
-Sinocyclocheilus grahami	Golden-line barbel
-Sinocyclocheilus rhinocerous	Horned golden-line barbel
-Sorex araneus	Shrew
-Sparus aurata	Gilthead seabream
-Spermophilus dauricus	Daurian ground squirrel
-Sphaeramia orbicularis	Orbiculate cardinalfish
-Sphenodon punctatus	Tuatara
-Stachyris ruficeps	Rufous-capped babbler
-Stegastes partitus	Bicolor damselfish
-Strigops habroptila	Kakapo
-Strix occidentalis caurina	Northern spotted owl
-Struthio camelus australis	African ostrich
-Suricata suricatta	Meerkat
-Sus scrofa	Pig
-Sus scrofa bamei	Pig - Bamei
-Sus scrofa berkshire	Pig - Berkshire
-Sus scrofa hampshire	Pig - Hampshire
-Sus scrofa jinhua	Pig - Jinhua
-Sus scrofa landrace	Pig - Landrace
-Sus scrofa largewhite	Pig - Largewhite
-Sus scrofa meishan	Pig - Meishan
-Sus scrofa pietrain	Pig - Pietrain
-Sus scrofa rongchang	Pig - Rongchang
-Sus scrofa tibetan	Pig - Tibetan
-Sus scrofa usmarc	Pig USMARC
-Sus scrofa wuzhishan	Pig - Wuzhishan
-Taeniopygia guttata	Zebra finch
-Takifugu rubripes	Fugu
-Terrapene carolina triunguis	Three-toed box turtle
-Tetraodon nigroviridis	Tetraodon
-Theropithecus gelada	Gelada
-Tupaia belangeri	Tree Shrew
-Tursiops truncatus	Dolphin
-Urocitellus parryii	Arctic ground squirrel
-Ursus americanus	American black bear
-Ursus maritimus	Polar bear
-Ursus thibetanus thibetanus	Asiatic black bear
-Varanus komodoensis	Komodo dragon
-Vicugna pacos	Alpaca
-Vombatus ursinus	Common wombat
-Vulpes vulpes	Red fox
-Xenopus tropicalis	Tropical clawed frog
-Xiphophorus couchianus	Monterrey platyfish
-Xiphophorus maculatus	Platyfish
-Zalophus californianus	California sea lion
-Zonotrichia albicollis	White-throated sparrow
-Zosterops lateralis melanops	Silver-eye
+Species name	Common name	Ensembl stableid Prefix
+Acanthochromis polyacanthus	Spiny chromis	ENSAPO
+Accipiter nisus	Eurasian sparrowhawk	ENSANI
+Ailuropoda melanoleuca	Giant panda	ENSAME
+Amazona collaria	Yellow-billed parrot	ENSACO
+Amphilophus citrinellus	Midas cichlid	ENSACI
+Amphiprion ocellaris	Clown anemonefish	ENSAOC
+Amphiprion percula	Orange clownfish	ENSAPE
+Anabas testudineus	Climbing perch	ENSATE
+Anas platyrhynchos	Mallard	ENSAPL
+Anas platyrhynchos platyrhynchos	Duck	ENSAPL
+Anas zonorhyncha	Eastern spot-billed duck	ENSAZO
+Anolis carolinensis	Green anole	ENSACA
+Anser brachyrhynchus	Pink-footed goose	ENSABR
+Anser cygnoides	Swan goose	ENSACD
+Aotus nancymaae	Ma's night monkey	ENSANA
+Apteryx haastii	Great spotted kiwi	ENSAHA
+Apteryx owenii	Little spotted kiwi	ENSAOW
+Apteryx rowi	Okarito brown kiwi	ENSARW
+Aquila chrysaetos chrysaetos	Golden eagle	ENSACC
+Astatotilapia calliptera	Eastern happy	ENSACL
+Astyanax mexicanus	Mexican tetra	ENSAMX
+Astyanax mexicanus pachon	Pachon cavefish	
+Athene cunicularia	Burrowing owl	ENSACU
+Balaenoptera musculus	Blue whale	ENSBMS
+Betta splendens	Siamese fighting fish	ENSBSL
+Bison bison bison	American bison	ENSBBB
+Bos grunniens	Domestic yak	ENSBGR
+Bos indicus hybrid	Hybrid - Bos Indicus	
+Bos mutus	Wild yak	ENSBMU
+Bos taurus	Cow	ENSBTA
+Bos taurus hybrid	Hybrid - Bos Taurus	
+Bubo bubo	Eurasian eagle-owl	ENSBOB
+Buteo japonicus	Eastern buzzard	ENSBJA
+Caenorhabditis elegans	Caenorhabditis elegans (PRJNA13758)	
+Cairina moschata domestica	Muscovy Duck (domestic type)	ENSCMM
+Calidris pugnax	Ruff	ENSCPU
+Calidris pygmaea	Spoon-billed sandpiper	ENSCPG
+Callithrix jacchus	White-tufted-ear marmoset	ENSCJA
+Callorhinchus milii	Elephant shark	ENSCMI
+Camarhynchus parvulus	Small tree finch	ENSCPV
+Camelus dromedarius	Arabian camel	ENSCDR
+Canis lupus dingo	Dingo	ENSCAF
+Canis lupus familiaris	Dog	ENSCAF
+Canis lupus familiarisbasenji	Dog - Basenji	
+Canis lupus familiarisboxer	Dog - Boxer	
+Canis lupus familiarisgreatdane	Dog - Great Dane	
+Canis lupus familiarisgsd	Dog - German Shepherd	
+Capra hircus	Goat	ENSCHI
+Capra hircus blackbengal	Goat (black bengal)	
+Carassius auratus	Goldfish	ENSCAR
+Carlito syrichta	Tarsier	ENSTSY
+Castor canadensis	American beaver	ENSCCN
+Catagonus wagneri	Chacoan peccary	ENSCWA
+Catharus ustulatus	Swainson's thrush	ENSCUS
+Cavia aperea	Brazilian guinea pig	ENSCAP
+Cavia porcellus	Guinea Pig	ENSCPO
+Cebus imitator	Panamanian white-faced capuchin	ENSCCA
+Cercocebus atys	Sooty mangabey	ENSCAT
+Cervus hanglu yarkandensis	Yarkand deer	ENSCHY
+Chelonoidis abingdonii	Abingdon island giant tortoise	ENSCAB
+Chelydra serpentina	Common snapping turtle	ENSCSR
+Chinchilla lanigera	Long-tailed chinchilla	ENSCLA
+Chlorocebus sabaeus	Vervet-AGM	ENSCSA
+Choloepus hoffmanni	Sloth	ENSCHO
+Chrysemys picta bellii	Painted turtle	ENSCPB
+Chrysolophus pictus	Golden pheasant	ENSCPI
+Ciona intestinalis	C.intestinalis	ENSCIN
+Ciona savignyi	C.savignyi	ENSCSAV
+Clupea harengus	Atlantic herring	ENSCHA
+Colobus angolensis palliatus	Angola colobus	ENSCAN
+Corvus moneduloides	New Caledonian crow	ENSCMU
+Cottoperca gobio	Channel bull blenny	ENSCGO
+Coturnix japonica	Japanese quail	ENSCJP
+Cricetulus griseus chok1gshd	Chinese hamster CHOK1GS	
+Cricetulus griseus crigri	Chinese hamster CriGri	
+Cricetulus griseus picr	Chinese hamster PICR	
+Crocodylus porosus	Australian saltwater crocodile	ENSCPR
+Cyanistes caeruleus	Blue tit	ENSCCE
+Cyclopterus lumpus	Lumpfish	ENSCLM
+Cynoglossus semilaevis	Tongue sole	ENSCSE
+Cyprinodon variegatus	Sheepshead minnow	ENSCVA
+Cyprinus carpio carpio	Common carp	ENSCCR
+Cyprinus carpio germanmirror	Common carp german mirror	
+Cyprinus carpio hebaored	Common carp hebao red	
+Cyprinus carpio huanghe	Common carp huanghe	
+Danio rerio	Zebrafish	ENSDAR
+Dasypus novemcinctus	Armadillo	ENSDNO
+Delphinapterus leucas	Beluga whale	ENSDLE
+Denticeps clupeoides	Denticle herring	ENSDCD
+Dicentrarchus labrax	European seabass	ENSDLA
+Dipodomys ordii	Kangaroo rat	ENSDOR
+Dromaius novaehollandiae	Emu	ENSDNV
+Drosophila melanogaster	Drosophila melanogaster (Fruit fly)	
+Echeneis naucrates	Live sharksucker	ENSENL
+Echinops telfairi	Lesser hedgehog tenrec	ENSETE
+Electrophorus electricus	Electric eel	ENSEEE
+Eptatretus burgeri	Hagfish	ENSEBU
+Equus asinus	Donkey	ENSEAS
+Equus caballus	Horse	ENSECA
+Erinaceus europaeus	Hedgehog	ENSEEU
+Erpetoichthys calabaricus	Reedfish	ENSECR
+Erythrura gouldiae	Gouldian finch	ENSEGO
+Esox lucius	Northern pike	ENSELU
+Falco tinnunculus	Common kestrel	ENSFTI
+Felis catus	Cat	ENSFCA
+Ficedula albicollis	Collared flycatcher	ENSFAL
+Fukomys damarensis	Damara mole rat	ENSFDA
+Fundulus heteroclitus	Mummichog	ENSFHE
+Gadus morhua	Atlantic cod	ENSGMO
+Gallus gallus	Chicken	ENSGAL
+Gallus gallus gca000002315v5	Chicken (Red Jungle fowl)	
+Gallus gallus gca016700215v2	Chicken (paternal White leghorn layer)	
+Gambusia affinis	Western mosquitofish	ENSGAF
+Gasterosteus aculeatus	Stickleback	ENSGAC
+Geospiza fortis	Medium ground-finch	ENSGFO
+Gopherus agassizii	Agassiz's desert tortoise	ENSGAG
+Gopherus evgoodei	Goodes thornscrub tortoise	ENSGEV
+Gorilla gorilla	Gorilla	
+Gouania willdenowi	Blunt-snouted clingfish	ENSGWI
+Haplochromis burtoni	Burton's mouthbrooder	ENSHBU
+Heterocephalus glaber female	Naked mole-rat female	
+Heterocephalus glaber male	Naked mole-rat male	
+Hippocampus comes	Tiger tail seahorse	ENSHCO
+Homo sapiens	Human	ENS
+Hucho hucho	Huchen	ENSHHU
+Ictalurus punctatus	Channel catfish	ENSIPU
+Ictidomys tridecemlineatus	Squirrel	ENSSTO
+Jaculus jaculus	Lesser Egyptian jerboa	ENSJJA
+Junco hyemalis	Dark-eyed junco	ENSJHY
+Kryptolebias marmoratus	Mangrove rivulus	ENSKMA
+Labrus bergylta	Ballan wrasse	ENSLBE
+Larimichthys crocea	Large yellow croaker	ENSLCR
+Lates calcarifer	Barramundi perch	ENSLCA
+Laticauda laticaudata	Blue-ringed sea krait	ENSLLT
+Latimeria chalumnae	Coelacanth	ENSLAC
+Lepidothrix coronata	Blue-crowned manakin	ENSLCO
+Lepisosteus oculatus	Spotted gar	ENSLOC
+Leptobrachium leishanense	Leishan spiny toad	ENSLLE
+Lonchura striata domestica	Bengalese finch	ENSLSD
+Loxodonta africana	Elephant	ENSLAF
+Lynx canadensis	Canada lynx	ENSLCN
+Macaca fascicularis	Crab-eating macaque	ENSMFA
+Macaca mulatta	Macaque	ENSMMU
+Macaca nemestrina	Pig-tailed macaque	ENSMNE
+Malurus cyaneus samueli	Superb fairywren	ENSMCS
+Manacus vitellinus	Golden-collared manakin	ENSMVI
+Mandrillus leucophaeus	Drill	ENSMLE
+Marmota marmota marmota	Alpine marmot	ENSMMM
+Mastacembelus armatus	Zig-zag eel	ENSMAM
+Maylandia zebra	Zebra mbuna	ENSMZE
+Meleagris gallopavo	Turkey	ENSMGA
+Melopsittacus undulatus	Budgerigar	ENSMUN
+Meriones unguiculatus	Mongolian gerbil	ENSMUG
+Mesocricetus auratus	Golden Hamster	ENSMAU
+Microcebus murinus	Mouse Lemur	ENSMIC
+Microtus ochrogaster	Prairie vole	ENSMOC
+Mola mola	Ocean sunfish	ENSMMO
+Monodelphis domestica	Opossum	ENSMOD
+Monodon monoceros	Narwhal	ENSMMN
+Monopterus albus	Swamp eel	ENSMAL
+Moschus moschiferus	Siberian musk deer	ENSMMS
+Mus caroli	Ryukyu mouse	MGP_CAROLIEiJ_
+Mus musculus	Mouse	MGP_C57BL6NJ_
+Mus musculus 129s1svimj	Mouse 129S1/SvImJ	
+Mus musculus aj	Mouse A/J	
+Mus musculus akrj	Mouse AKR/J	
+Mus musculus balbcj	Mouse BALB/cJ	
+Mus musculus c3hhej	Mouse C3H/HeJ	
+Mus musculus c57bl6nj	Mouse C57BL/6NJ	
+Mus musculus casteij	Mouse CAST/EiJ	
+Mus musculus cbaj	Mouse CBA/J	
+Mus musculus dba2j	Mouse DBA/2J	
+Mus musculus fvbnj	Mouse FVB/NJ	
+Mus musculus lpj	Mouse LP/J	
+Mus musculus nodshiltj	Mouse NOD/ShiLtJ	
+Mus musculus nzohlltj	Mouse NZO/HlLtJ	
+Mus musculus pwkphj	Mouse PWK/PhJ	
+Mus musculus wsbeij	Mouse WSB/EiJ	
+Mus pahari	Shrew mouse	MGP_PahariEiJ_
+Mus spicilegus	Steppe mouse	ENSMSI
+Mus spretus	Algerian mouse	MGP_SPRETEiJ_
+Mustela putorius furo	Ferret	ENSMPU
+Myotis lucifugus	Microbat	ENSMLU
+Myripristis murdjan	Pinecone soldierfish	ENSMMD
+Naja naja	Indian cobra	ENSNNA
+Nannospalax galili	Upper Galilee mountains blind mole rat	ENSNGA
+Neogobius melanostomus	Round goby	ENSNML
+Neolamprologus brichardi	Lyretail cichlid	ENSNBR
+Neovison vison	American mink	ENSNVI
+Nomascus leucogenys	Gibbon	ENSNLE
+Notamacropus eugenii	Wallaby	ENSMEU
+Notechis scutatus	Mainland tiger snake	ENSNSU
+Nothobranchius furzeri	Turquoise killifish	ENSNFU
+Nothoprocta perdicaria	Chilean tinamou	ENSNPE
+Numida meleagris	Helmeted guineafowl	ENSNME
+Ochotona princeps	Pika	ENSOPR
+Octodon degus	Degu	ENSODE
+Oncorhynchus kisutch	Coho salmon	ENSOKI
+Oncorhynchus mykiss	Rainbow trout	ENSOMY
+Oncorhynchus tshawytscha	Chinook salmon	ENSOTS
+Oreochromis aureus	Blue tilapia	ENSOAB
+Oreochromis niloticus	Nile tilapia	ENSONI
+Ornithorhynchus anatinus	Platypus	ENSOAN
+Oryctolagus cuniculus	Rabbit	ENSOCU
+Oryzias javanicus	Javanese ricefish	ENSOJA
+Oryzias latipes	Japanese medaka HdrR	ENSORL
+Oryzias latipes hni	Japanese medaka HNI	
+Oryzias latipes hsok	Japanese medaka HSOK	
+Oryzias melastigma	Indian medaka	ENSOME
+Oryzias sinensis	Chinese medaka	ENSOSI
+Otolemur garnettii	Bushbaby	ENSOGA
+Otus sunia	Oriental scops-owl	ENSOSU
+Ovis aries	Sheep (texel)	ENSOAR
+Ovis aries rambouillet	Sheep	
+Pan paniscus	Bonobo	ENSPPA
+Pan troglodytes	Chimpanzee	ENSPTR
+Panthera leo	Lion	ENSPLO
+Panthera pardus	Leopard	ENSPPR
+Panthera tigris altaica	Tiger	ENSPTI
+Papio anubis	Olive baboon	ENSPAN
+Parambassis ranga	Indian glassy fish	ENSPRN
+Paramormyrops kingsleyae	Paramormyrops kingsleyae	ENSPKI
+Parus major	Great Tit	ENSPMJ
+Pavo cristatus	Indian peafowl	ENSPST
+Pelodiscus sinensis	Chinese softshell turtle	ENSPSI
+Pelusios castaneus	West African mud turtle	ENSPCE
+Periophthalmus magnuspinnatus	Periophthalmus magnuspinnatus	ENSPMG
+Peromyscus maniculatus bairdii	Northern American deer mouse	ENSPEM
+Petromyzon marinus	Lamprey	ENSPMA
+Phascolarctos cinereus	Koala	ENSPCI
+Phasianus colchicus	Ring-necked pheasant	ENSPCL
+Phocoena sinus	Vaquita	ENSPSN
+Physeter catodon	Sperm whale	ENSPCT
+Piliocolobus tephrosceles	Ugandan red Colobus	ENSPTE
+Podarcis muralis	Common wall lizard	ENSPMR
+Poecilia formosa	Amazon molly	ENSPFO
+Poecilia latipinna	Sailfin molly	ENSPLA
+Poecilia mexicana	Shortfin molly	ENSPME
+Poecilia reticulata	Guppy	ENSPRE
+Pogona vitticeps	Central bearded dragon	ENSPVI
+Pongo abelii	Sumatran orangutan	ENSPPY
+Procavia capensis	Hyrax	ENSPCA
+Prolemur simus	Greater bamboo lemur	ENSPSM
+Propithecus coquereli	Coquerel's sifaka	ENSPCO
+Pseudonaja textilis	Eastern brown snake	ENSPTX
+Pteropus vampyrus	Megabat	ENSPVA
+Pundamilia nyererei	Makobe Island cichlid	ENSPNY
+Pygocentrus nattereri	Red-bellied piranha	ENSPNA
+Rattus norvegicus	Rat	ENSRNO
+Rattus norvegicus shrspbbbutx	Rat - SHRSP/BbbUtx	
+Rattus norvegicus shrutx	Rat - SHR/Utx RGD_8142385	
+Rattus norvegicus wkybbb	Rat - WKY/Bbb RGD_1581635	
+Rhinolophus ferrumequinum	Greater horseshoe bat	ENSRFE
+Rhinopithecus bieti	Black snub-nosed monkey	ENSRBI
+Rhinopithecus roxellana	Golden snub-nosed monkey	ENSRRO
+Saccharomyces cerevisiae	Saccharomyces cerevisiae	
+Saimiri boliviensis boliviensis	Bolivian squirrel monkey	ENSSBO
+Salarias fasciatus	Jewelled blenny	ENSSFA
+Salmo salar	Atlantic salmon	ENSSSA
+Salmo trutta	Brown trout	ENSSTU
+Salvator merianae	Argentine black and white tegu	ENSSMR
+Sander lucioperca	Pike-perch	ENSSLU
+Sarcophilus harrisii	Tasmanian devil	ENSSHA
+Sciurus vulgaris	Eurasian red squirrel	ENSSVL
+Scleropages formosus	Asian bonytongue	ENSCHA
+Scophthalmus maximus	Turbot	ENSSMA
+Serinus canaria	Common canary	ENSSCA
+Seriola dumerili	Greater amberjack	ENSSDU
+Seriola lalandi dorsalis	Yellowtail amberjack	ENSSLD
+Sinocyclocheilus anshuiensis	Blind barbel	ENSSAN
+Sinocyclocheilus grahami	Golden-line barbel	ENSSGR
+Sinocyclocheilus rhinocerous	Horned golden-line barbel	ENSSRH
+Sorex araneus	Shrew	ENSSAR
+Sparus aurata	Gilthead seabream	ENSSAU
+Spermophilus dauricus	Daurian ground squirrel	ENSSDA
+Sphaeramia orbicularis	Orbiculate cardinalfish	ENSSOR
+Sphenodon punctatus	Tuatara	ENSSPU
+Stachyris ruficeps	Rufous-capped babbler	
+Stegastes partitus	Bicolor damselfish	ENSSPA
+Strigops habroptila	Kakapo	ENSSHB
+Strix occidentalis caurina	Northern spotted owl	ENSSOC
+Struthio camelus australis	African ostrich	ENSSCU
+Suricata suricatta	Meerkat	ENSSSU
+Sus scrofa	Pig	ENSSSC
+Sus scrofa bamei	Pig - Bamei	
+Sus scrofa berkshire	Pig - Berkshire	
+Sus scrofa hampshire	Pig - Hampshire	
+Sus scrofa jinhua	Pig - Jinhua	
+Sus scrofa landrace	Pig - Landrace	
+Sus scrofa largewhite	Pig - Largewhite	
+Sus scrofa meishan	Pig - Meishan	
+Sus scrofa pietrain	Pig - Pietrain	
+Sus scrofa rongchang	Pig - Rongchang	
+Sus scrofa tibetan	Pig - Tibetan	
+Sus scrofa usmarc	Pig USMARC	
+Sus scrofa wuzhishan	Pig - Wuzhishan	
+Taeniopygia guttata	Zebra finch	ENSTGU
+Takifugu rubripes	Fugu	ENSTRU
+Terrapene carolina triunguis	Three-toed box turtle	ENSTMT
+Tetraodon nigroviridis	Tetraodon	ENSTNI
+Theropithecus gelada	Gelada	ENSTGE
+Tupaia belangeri	Tree Shrew	ENSTBE
+Tursiops truncatus	Dolphin	ENSTTR
+Urocitellus parryii	Arctic ground squirrel	ENSUPA
+Ursus americanus	American black bear	ENSUAM
+Ursus maritimus	Polar bear	ENSUMA
+Ursus thibetanus thibetanus	Asiatic black bear	ENSUTT
+Varanus komodoensis	Komodo dragon	ENSVKK
+Vicugna pacos	Alpaca	ENSVPA
+Vombatus ursinus	Common wombat	ENSVUR
+Vulpes vulpes	Red fox	ENSVVU
+Xenopus tropicalis	Tropical clawed frog	ENSXET
+Xiphophorus couchianus	Monterrey platyfish	ENSXCO
+Xiphophorus maculatus	Platyfish	ENSXMA
+Zalophus californianus	California sea lion	ENSZCA
+Zonotrichia albicollis	White-throated sparrow	ENSZAL
+Zosterops lateralis melanops	Silver-eye	ENSZLM

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -85,3 +85,17 @@ class TestSpeciesNamemaps(TestCase):
 )
 def test_contains(name):
     assert name in Species
+
+
+@pytest.mark.parametrize("feature_prefix", ("E", "FM", "G", "GT", "P", "R", "T"))
+def test_db_prefix_from_stableid(feature_prefix):
+    stableid = f"ENSPTI{feature_prefix}012345678911"
+    expect = "panthera_tigris_altaica"
+    got = Species.get_db_prefix_from_stableid(stableid)
+    assert got == expect
+
+
+@pytest.mark.parametrize("invalid", ("blah", "ENSPTIX012345678911")[1:])
+def test_db_prefix_from_stableid_fail(invalid):
+    with pytest.raises(ValueError):
+        Species.get_db_prefix_from_stableid(invalid)


### PR DESCRIPTION
[CHANGED] updated the species.tsv file

[NEW] SpeciesMap.get_db_prefix_from_stableid() takes a stableid and returns
    the Ensembl db prefix