### PR TITLE
ENH: mods to EnsemblGffRecord

### DIFF
--- a/src/ensembl_lite/_align.py
+++ b/src/ensembl_lite/_align.py
@@ -98,7 +98,7 @@ class GapStore(elt_mixin.Hdf5Mixin):
         try:
             self._file = h5py.File(source, mode=self.mode, **h5_kwargs)
         except OSError:
-            print(source)
+            print(f"{source=}")
             raise
 
         if "r" not in self.mode and "align_name" not in self._file.attrs:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -274,7 +274,6 @@ def test_select_alignment_minus_strand(start_end, namer):
         spans=[(max(1, start or 0), min(end or 12, 12))],
     )
     expect = aln[ft.map.start : min(ft.map.end, 12)]
-
     # mouse sequence is on minus strand, so need to adjust
     # coordinates for query
     s2 = aln.get_seq("s2")
@@ -305,7 +304,7 @@ def test_select_alignment_minus_strand(start_end, namer):
         )
     )
     # drop the strand info
-    assert len(got) == 1
+    assert len(got) == 1, f"{s2_ft=}"
     assert got[0].to_dict() == expect.to_dict()
 
 


### PR DESCRIPTION
[NEW] .spans_array() returns the spans attribute as a 32-bit
    numpy array

[CHANGED] .update_record() (from update_from_attrs()) now updates
    start / stop values, also added a flag attribute to only do this
    once

[NEW] added _array_int32 function for converting span data to numpy array

[NEW] .to_record() method is responsible for preparing a record
    for addition into a database. Has optional control over whether
    to convert the spans numpy array to a BLOB for db storage. Note
    that this not used for sqlite3 since cogent3 defines a custom array
    field that handles that.