### PR TITLE
Convert alignment lookup storage to duckdb and parquet from sqlite3

### DIFF
--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -129,7 +129,7 @@ class GapStore(eti_mixin.Hdf5Mixin):
             name=index,
             data=gaps,
             chunks=True,
-            **eti_util._HDF5_BLOSC2_KWARGS,
+            **eti_util.HDF5_BLOSC2_KWARGS,
         )
         self._file.flush()
 

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -239,7 +239,7 @@ class SeqsDataHdf5(eti_mixin.Hdf5Mixin, SeqsDataABC):
             name=seqid,
             data=seq,
             chunks=True,
-            **eti_util._HDF5_BLOSC2_KWARGS,
+            **eti_util.HDF5_BLOSC2_KWARGS,
         )
 
     def add_records(self, *, records: typing.Iterable[list[str, str]]) -> None:

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -24,7 +24,7 @@ from numpy.typing import NDArray
 import ensembl_tui._annotation as eti_annots
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _species as eti_species
-from ensembl_tui import _storage_mixin as eti_mixin
+from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
 from ensembl_tui._faster_fasta import quicka_parser
 
@@ -165,7 +165,7 @@ class arr2str:  # noqa: N801
 
 
 @dataclasses.dataclass
-class SeqsDataHdf5(eti_mixin.Hdf5Mixin, SeqsDataABC):
+class SeqsDataHdf5(eti_storage.Hdf5Mixin, SeqsDataABC):
     """HDF5 sequence data storage"""
 
     def __init__(

--- a/src/ensembl_tui/_ingest_align.py
+++ b/src/ensembl_tui/_ingest_align.py
@@ -1,0 +1,152 @@
+import pathlib
+import typing
+
+import duckdb
+import numpy
+import rich.progress as rich_progress
+from cogent3 import make_seq
+from cogent3.app.composable import LOADER, define_app
+from cogent3.app.typing import IdentifierType
+
+from ensembl_tui import _align as eti_align
+from ensembl_tui import _config as eti_config
+from ensembl_tui import _ingest_annotation as eti_db_ingest
+from ensembl_tui import _util as eti_util
+from ensembl_tui._maf import parse
+
+_no_gaps = numpy.array([], dtype=numpy.int32)
+
+
+def seq2gaps(record: dict) -> eti_align.AlignRecord:
+    seq = make_seq(record.pop("seq"))
+    indel_map, _ = seq.parse_out_gaps()
+    if indel_map.num_gaps:
+        record["gap_spans"] = numpy.array(
+            [indel_map.gap_pos, indel_map.get_gap_lengths()],
+            dtype=numpy.int32,
+        ).T
+    else:
+        record["gap_spans"] = _no_gaps
+    return eti_align.AlignRecord(**record)
+
+
+@define_app(app_type=LOADER)
+class load_align_records:  # noqa: N801
+    def __init__(self, species: set[str] | None = None) -> None:
+        self.species = species or {}
+
+    def main(self, path: IdentifierType) -> list[eti_align.AlignRecord]:
+        records = []
+        for block_id, align in parse(path):
+            converted = []
+            for maf_name, seq in align.items():
+                if self.species and maf_name.species not in self.species:
+                    continue
+                record = maf_name.to_dict()
+                record["block_id"] = block_id
+                record["source"] = path.name
+                record["seq"] = seq
+                converted.append(seq2gaps(record))
+            records.extend(converted)
+        return records
+
+
+def make_alignment_aggregator_db() -> duckdb.DuckDBPyConnection:
+    conn = duckdb.connect(":memory:")
+    conn.sql("CREATE SEQUENCE align_id_seq")
+    columns = ", ".join(eti_align.ALIGN_ATTR_SCHEMA)
+    conn.sql(f"CREATE TABLE align_blocks ({columns})")
+    return conn
+
+
+def add_records(
+    conn: duckdb.DuckDBPyConnection,
+    records: typing.Sequence[eti_align.AlignRecord],
+    gap_store: eti_align.GapStore,
+    progress: rich_progress.Progress | None = None,
+) -> None:
+    if not records:
+        return
+    # we need to identify block_id's that have already been used
+    col_order = [c for c in eti_align.ALIGN_ATTR_COLS if c != "align_id"]
+    block_ids = tuple({r.block_id for r in records})
+    val_placeholder = ", ".join("?" * len(block_ids))
+    sql = f"SELECT DISTINCT(block_id) from align_blocks WHERE block_id IN ({val_placeholder})"
+    used = {r[0] for r in conn.sql(sql, params=block_ids).fetchall()}
+
+    val_placeholder = ", ".join("?" * len(col_order))
+    sql = (
+        f"INSERT INTO align_blocks ({', '.join(col_order)}) VALUES ({val_placeholder})"
+    )
+    rowid_sql = "SELECT currval('align_id_seq')"
+    if progress is not None:
+        msg = "Writings aligns ✍️"
+        writing = progress.add_task(total=len(records), description=msg, advance=0)
+
+    for record in records:
+        if record.block_id in used:
+            continue
+
+        conn.sql(sql, params=[record[c] for c in col_order])
+        index = conn.sql(rowid_sql).fetchone()[0]
+        gap_store.add_record(index=index, gaps=record.gap_spans)
+        if progress is not None:
+            progress.update(writing, description=msg, advance=1)
+
+    if progress is not None:
+        progress.remove_task(writing)
+
+
+def install_alignment(
+    config: eti_config.Config,
+    align_name: str,
+    progress: rich_progress.Progress | None = None,
+    max_workers: int | None = None,
+) -> pathlib.Path:
+    src_dir = config.staging_aligns / align_name
+    dest_dir = config.install_aligns / align_name
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    paths = list(src_dir.glob(f"{align_name}*maf*"))
+    aln_loader = load_align_records(set(config.db_names))
+    agg = make_alignment_aggregator_db()
+    records = []
+    series = eti_util.get_iterable_tasks(
+        func=aln_loader,
+        series=paths,
+        max_workers=max_workers,
+    )
+    gap_path = dest_dir / f"{dest_dir.stem}.{eti_align.GAP_STORE_SUFFIX}"
+
+    gap_store = eti_align.GapStore(
+        source=gap_path,
+        align_name=align_name,
+        mode="w",
+        in_memory=False,
+    )
+
+    if progress is not None:
+        msg = "Reading aligns 📖"
+        reading = progress.add_task(total=len(paths), description=msg, advance=0)
+
+    for result in series:
+        if not result:
+            msg = f"{result=}"
+            raise RuntimeError(msg)
+
+        records.extend(result)
+
+        if progress is not None:
+            progress.update(reading, description=msg, advance=1)
+
+    if progress is not None:
+        progress.remove_task(reading)
+
+    add_records(conn=agg, records=records, gap_store=gap_store, progress=progress)
+    gap_store.close()
+    # write the parquet file, returns patrh to that file
+    return eti_db_ingest.export_parquet(
+        con=agg,
+        table_name="align_blocks",
+        dest_dir=dest_dir,
+    )

--- a/src/ensembl_tui/_ingest_homology.py
+++ b/src/ensembl_tui/_ingest_homology.py
@@ -154,7 +154,7 @@ class HomologyAggregator:
         sql = "INSERT OR IGNORE INTO member(stableid_id, homology_id) VALUES (?, ?)"
         self.conn.executemany(sql, parameters=values)
 
-    def finish(self):
+    def commit(self):
         # add the indexes for species and relationships
         relationships = list(self._relationship_indexer)
         sql = "INSERT OR IGNORE INTO relationship(relationship_id, homology_type) VALUES (?,?)"
@@ -286,4 +286,4 @@ def local_install_homology(
         for rel_type, records in grouped.items():
             agg.add_records(records=records, relationship_type=rel_type)
 
-    agg.finish()
+    agg.commit()

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -93,7 +93,7 @@ def local_install_alignments(
     max_workers: int | None,
     verbose: bool = False,
     progress: Progress | None = None,
-):
+) -> None:
     if force_overwrite:
         shutil.rmtree(config.install_aligns, ignore_errors=True)
 
@@ -141,7 +141,7 @@ def local_install_alignments(
         db.close()
 
     if verbose:
-        print("Finished installing alignments")
+        eti_util.print_colour("\nFinished installing alignments", "yellow")
 
 
 def local_install_homology(

--- a/src/ensembl_tui/_maf.py
+++ b/src/ensembl_tui/_maf.py
@@ -33,10 +33,11 @@ def _get_alignment_block_indices(data: list[str]) -> list[tuple[int, int]]:
 
 
 def process_id_line(line: str) -> int:
-    match = _id_pattern.search(line)
-    if not match:
-        raise ValueError(f"{line=} is not a tree id line")
-    return int(match.group())
+    if match := _id_pattern.search(line):
+        return int(match.group())
+
+    msg = f"{line=} is not a tree id line"
+    raise ValueError(msg)
 
 
 def process_maf_line(line: str) -> tuple[eti_name.MafName, str]:

--- a/src/ensembl_tui/_maf.py
+++ b/src/ensembl_tui/_maf.py
@@ -4,12 +4,8 @@
 import re
 import typing
 
-import numpy
-from cogent3 import make_seq, open_
-from cogent3.app.composable import LOADER, define_app
-from cogent3.app.typing import IdentifierType
+from cogent3 import open_
 
-from ensembl_tui import _align as eti_align
 from ensembl_tui import _name as eti_name
 from ensembl_tui import _util as eti_util
 
@@ -80,37 +76,3 @@ def parse(
     for block_start, block_end in blocks:
         block_id = process_id_line(data[block_start])
         yield block_id, _get_seqs(data[block_start + 1 : block_end])
-
-
-def seq2gaps(record: dict) -> eti_align.AlignRecord:
-    seq = make_seq(record.pop("seq"))
-    indel_map, _ = seq.parse_out_gaps()
-    if indel_map.num_gaps:
-        record["gap_spans"] = numpy.array(
-            [indel_map.gap_pos, indel_map.get_gap_lengths()],
-            dtype=numpy.int32,
-        ).T
-    else:
-        record["gap_spans"] = numpy.array([], dtype=numpy.int32)
-    return eti_align.AlignRecord(**record)
-
-
-@define_app(app_type=LOADER)
-class load_align_records:
-    def __init__(self, species: set[str] | None = None):
-        self.species = species or {}
-
-    def main(self, path: IdentifierType) -> list[eti_align.AlignRecord]:
-        records = []
-        for block_id, align in parse(path):
-            converted = []
-            for maf_name, seq in align.items():
-                if self.species and maf_name.species not in self.species:
-                    continue
-                record = maf_name.to_dict()
-                record["block_id"] = block_id
-                record["source"] = path.name
-                record["seq"] = seq
-                converted.append(seq2gaps(record))
-            records.extend(converted)
-        return records

--- a/src/ensembl_tui/_mysql_core_attr.py
+++ b/src/ensembl_tui/_mysql_core_attr.py
@@ -8,10 +8,7 @@ import typing
 import duckdb
 import numpy
 
-
-def _make_column_constant(schema: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(c.split()[0] for c in schema)
-
+from ensembl_tui import _util as eti_util
 
 TRANSCRIPT_ATTR_SCHEMA = (
     "gene_id INTEGER",
@@ -25,7 +22,7 @@ TRANSCRIPT_ATTR_SCHEMA = (
     "transcript_stable_id TEXT",
     "cds_stable_id TEXT",
 )
-TRANSCRIPT_ATTR_COLS = _make_column_constant(TRANSCRIPT_ATTR_SCHEMA)
+TRANSCRIPT_ATTR_COLS = eti_util.make_column_constant(TRANSCRIPT_ATTR_SCHEMA)
 GENE_ATTR_SCHEMA = (
     "gene_id INTEGER",
     "stable_id TEXT",
@@ -37,7 +34,7 @@ GENE_ATTR_SCHEMA = (
     "strand TINYINT",
     "symbol TEXT",
 )
-GENE_ATTR_COLS = _make_column_constant(GENE_ATTR_SCHEMA)
+GENE_ATTR_COLS = eti_util.make_column_constant(GENE_ATTR_SCHEMA)
 
 
 def array_to_blob(data: numpy.ndarray) -> bytes:

--- a/src/ensembl_tui/_storage_mixin.py
+++ b/src/ensembl_tui/_storage_mixin.py
@@ -140,6 +140,9 @@ class DuckdbParquetBase:
 
         self._conn = None
 
+        if not source.exists():
+            msg = f"{self._source} does not exist"
+            raise FileNotFoundError(msg)
         if not source.is_dir():
             msg = f"{self._source} is not a directory"
             raise OSError(msg)

--- a/src/ensembl_tui/_storage_mixin.py
+++ b/src/ensembl_tui/_storage_mixin.py
@@ -3,9 +3,12 @@ import dataclasses
 import functools
 import io
 import os
+import pathlib
 import sqlite3
 
+import duckdb
 import numpy
+import typing_extensions
 
 from ensembl_tui import _util as eti_util
 
@@ -198,3 +201,73 @@ class Hdf5Mixin(eti_util.SerialisableMixin):
                     self._file.close()
 
         self._is_open = False
+
+
+class ViewMixin:
+    _source: pathlib.Path  # override in subclass
+
+    @property
+    def species(self) -> str:
+        return self._source.name
+
+
+@dataclasses.dataclass(slots=True)
+class DuckdbParquetBase:
+    source: dataclasses.InitVar[pathlib.Path]
+    # db is for testing purposes
+    db: dataclasses.InitVar[duckdb.DuckDBPyConnection | None] = None
+    _source: pathlib.Path = dataclasses.field(init=False)
+    _conn: duckdb.DuckDBPyConnection = dataclasses.field(init=False, default=None)  # type: ignore
+    _tables: tuple[str, ...] | tuple = ()
+
+    def __post_init__(
+        self,
+        source: pathlib.Path,
+        db: duckdb.DuckDBPyConnection | None,
+    ) -> None:
+        source = pathlib.Path(source)
+        self._source = source
+        if db:
+            self._conn = db
+            return
+
+        self._conn = None
+
+        if not source.is_dir():
+            msg = f"{self._source} is not a directory"
+            raise OSError(msg)
+
+        if hasattr(self, "_post_init"):
+            self._post_init()
+
+    @property
+    def conn(self) -> duckdb.DuckDBPyConnection:
+        if self._conn is None:
+            self._conn = duckdb.connect(":memory:")
+            for table in self._tables:
+                parquet_file = self._source / f"{table}.parquet"
+                if not parquet_file.exists():
+                    msg = f"{parquet_file} does not exist"
+                    raise FileNotFoundError(msg)
+
+                sql = f"CREATE TABLE {table} AS SELECT * FROM read_parquet('{parquet_file}')"
+                self._conn.sql(sql)
+
+        return self._conn
+
+    def __len__(self) -> int:
+        return self.num_records()
+
+    def __eq__(self, other: typing_extensions.Self) -> bool:
+        return other.conn is self.conn
+
+    @property
+    def source(self) -> pathlib.Path:
+        return self._source
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def num_records(self) -> int:  # pragma: no cover
+        # override in subclass
+        raise NotImplementedError

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -565,3 +565,7 @@ def tempdir() -> pathlib.Path:
     """context manager returns a temporary directory"""
     with tempfile.TemporaryDirectory() as temp_dir:
         yield pathlib.Path(temp_dir)
+
+
+def make_column_constant(schema: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(c.split()[0] for c in schema)

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -37,7 +37,7 @@ except (NotImplementedError, ImportError):
     keep_running = contextlib.nullcontext
 
 
-_HDF5_BLOSC2_KWARGS = hdf5plugin.Blosc2(
+HDF5_BLOSC2_KWARGS = hdf5plugin.Blosc2(
     cname="blosclz",
     clevel=9,
     filters=hdf5plugin.Blosc2.BITSHUFFLE,

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -589,3 +589,13 @@ def test_pickling_db(db_align):
     pkl = pickle.dumps(db_align)  # nosec B301
     upkl = pickle.loads(pkl)  # nosec B301  # noqa: S301
     assert db_align.source == upkl.source
+
+
+def test_aligndb_post_init_failure(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        eti_align.AlignDb(source="/non/existent/directory")
+
+    outfile = tmp_path / "textfile.txt"
+    outfile.write_text("blah")
+    with pytest.raises(OSError):
+        eti_align.AlignDb(source="/non/existent/directory")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,9 @@ def test_installed(installed):
     assert r.exit_code == 0, r.output
     assert "Installed genomes" in r.output
     assert "caenorhabditis_elegans" in r.output
+    path = config.installed_genome("caenorhabditis_elegans")
+    # should be 2 combined attr parquet files
+    assert len(list(path.glob("*attr.parquet"))) == 2
 
 
 @pytest.mark.slow

--- a/tests/test_dbs.py
+++ b/tests/test_dbs.py
@@ -1,11 +1,7 @@
-import pickle  # nosec B403
-
 import numpy
 import pytest
-from cogent3 import load_table
 
 from ensembl_tui import _align as eti_align
-from ensembl_tui import _ingest_homology as homology_ingest
 from ensembl_tui import _maf as eti_maf
 from ensembl_tui import _storage_mixin as eti_mixin
 
@@ -60,34 +56,6 @@ def test_db_align_add_records(db_align):
 @pytest.mark.parametrize("func", [str, repr])
 def test_db_align_repr(db_align, func):
     func(db_align)
-
-
-@pytest.fixture
-def hom_dir(DATA_DIR, tmp_path):
-    path = DATA_DIR / "small_protein_homologies.tsv.gz"
-    table = load_table(path)
-    outpath = tmp_path / "small_1.tsv.gz"
-    table[:1].write(outpath)
-    outpath = tmp_path / "small_2.tsv.gz"
-    table[1:2].write(outpath)
-    return tmp_path
-
-
-def test_extract_homology_data(hom_dir):
-    loader = homology_ingest.load_homologies(
-        {"gorilla_gorilla", "nomascus_leucogenys", "notamacropus_eugenii"},
-    )
-    records = []
-    for result in loader.as_completed(hom_dir.glob("*.tsv.gz"), show_progress=False):
-        records.extend(result.obj)
-    assert len(records) == 2
-
-
-def test_pickling_db(db_align):
-    # should not fail
-    pkl = pickle.dumps(db_align)  # nosec B301
-    upkl = pickle.loads(pkl)  # nosec B301  # noqa: S301
-    assert db_align.source == upkl.source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dbs.py
+++ b/tests/test_dbs.py
@@ -1,61 +1,7 @@
 import numpy
 import pytest
 
-from ensembl_tui import _align as eti_align
-from ensembl_tui import _maf as eti_maf
-from ensembl_tui import _storage_mixin as eti_mixin
-
-
-@pytest.fixture
-def db_align(DATA_DIR, tmp_path):
-    # apps are callable
-    records = eti_maf.load_align_records()(  # pylint: disable=not-callable
-        DATA_DIR / "tiny.maf",
-    )
-    outpath = tmp_path / "blah.sqlitedb"
-    db = eti_align.AlignDb(source=outpath)
-    db.add_records(records)
-    db.close()
-    return eti_align.AlignDb(source=outpath)
-
-
-def test_db_align(db_align):
-    orig = len(db_align)
-    source = db_align.source
-    db_align.close()
-    got = eti_align.AlignDb(source=source)
-    assert len(got) == orig
-
-
-def test_db_align_add_records(db_align):
-    gap_spans = numpy.array([[2, 5], [7, 1]], dtype=int)
-    orig = {
-        "source": "blah",
-        "block_id": 42,
-        "species": "human",
-        "seqid": "1",
-        "start": 22,
-        "stop": 42,
-        "strand": "-",
-    }
-    records = [eti_align.AlignRecord(gap_spans=gap_spans, **orig.copy())]
-    db_align.add_records(records)
-    got = next(
-        iter(
-            db_align._execute_sql(
-                f"SELECT * from {db_align.table_name} where block_id=?",
-                (42,),
-            ),
-        ),
-    )
-    got = {k: got[k] for k in orig if k != "id"}
-    # gap_spans not stored in the db, but in a GapStore
-    assert got == orig
-
-
-@pytest.mark.parametrize("func", [str, repr])
-def test_db_align_repr(db_align, func):
-    func(db_align)
+from ensembl_tui import _storage_mixin as eti_storage
 
 
 @pytest.mark.parametrize(
@@ -63,9 +9,9 @@ def test_db_align_repr(db_align, func):
     [numpy.array([], dtype=numpy.int32), numpy.array([0, 3], dtype=numpy.uint8)],
 )
 def test_array_blob_roundtrip(data):
-    blob = eti_mixin.array_to_blob(data)
+    blob = eti_storage.array_to_blob(data)
     assert isinstance(blob, bytes)
-    inflated = eti_mixin.blob_to_array(blob)
+    inflated = eti_storage.blob_to_array(blob)
     assert numpy.array_equal(inflated, data)
     assert inflated.dtype is data.dtype
 
@@ -74,10 +20,10 @@ def test_array_blob_roundtrip(data):
     "data",
     [
         numpy.array([0, 3], dtype=numpy.uint8),
-        eti_mixin.array_to_blob(numpy.array([0, 3], dtype=numpy.uint8)),
+        eti_storage.array_to_blob(numpy.array([0, 3], dtype=numpy.uint8)),
     ],
 )
 def test_blob_array(data):
     # handles array or bytes as input
-    inflated = eti_mixin.blob_to_array(data)
+    inflated = eti_storage.blob_to_array(data)
     assert numpy.array_equal(inflated, numpy.array([0, 3], dtype=numpy.uint8))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -187,8 +187,10 @@ def invalid_downloaded_cfg(downloaded_cfg, request):
 
 def test_install_features_invalid(invalid_downloaded_cfg):
     cfg = eti_config.read_config(invalid_downloaded_cfg)
-    with pytest.raises(FileNotFoundError):
-        eti_db_ingest.install_parquet_tables(config=cfg)
+    with pytest.raises(FileNotFoundError):  # noqa: PT012
+        app = eti_db_ingest.mysql_dump_to_parquet(config=cfg)
+        # an exception during call in finding mysql file
+        app.main("saccharomyces_cerevisiae")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Convert alignment lookup storage to DuckDB and Parquet.

New Features:
- Store alignment data in Parquet format using DuckDB.

Enhancements:
- Store alignment coordinates and gaps separately to improve query performance.