### PR TITLE
ENH: allow specifying the directory for creating tmpdir

### DIFF
--- a/src/ensembl_tui/_ingest_annotation.py
+++ b/src/ensembl_tui/_ingest_annotation.py
@@ -49,7 +49,7 @@ def tempdb(
     if not source_db_path.exists():
         raise FileNotFoundError(source_db_path)
 
-    with eti_util.tempdir() as temp_dir:
+    with eti_util.tempdir(working_dir=eti_util.CWD) as temp_dir:
         temp_db_path = pathlib.Path(temp_dir) / source_db_path.name
         shutil.copy2(source_db_path, temp_db_path)
 

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -36,6 +36,7 @@ try:
 except (NotImplementedError, ImportError):
     keep_running = contextlib.nullcontext
 
+CWD = pathlib.Path.cwd()
 
 HDF5_BLOSC2_KWARGS = hdf5plugin.Blosc2(
     cname="blosclz",
@@ -561,9 +562,9 @@ class category_indexer:  # noqa: N801
 
 
 @contextlib.contextmanager
-def tempdir() -> pathlib.Path:
-    """context manager returns a temporary directory"""
-    with tempfile.TemporaryDirectory() as temp_dir:
+def tempdir(working_dir: pathlib.Path | str | None = None) -> pathlib.Path:
+    """context manager returns a temporary directory in working_dir"""
+    with tempfile.TemporaryDirectory(dir=working_dir) as temp_dir:
         yield pathlib.Path(temp_dir)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add a `working_dir` parameter to the `tempdir` context manager to create the temporary directory in the specified location.