### PR TITLE
MAINT: refactor homology installation

### DIFF
--- a/src/ensembl_tui/_homology.py
+++ b/src/ensembl_tui/_homology.py
@@ -1,11 +1,9 @@
 import dataclasses
 import typing
 
-import blosc2
 import typing_extensions
 from cogent3 import make_table, make_unaligned_seqs
 from cogent3.app.composable import NotCompleted, define_app
-from cogent3.app.io import compress, decompress, pickle_it, unpickle_it
 from cogent3.app.typing import (
     SeqsCollectionType,
 )
@@ -14,12 +12,16 @@ from cogent3.util.io import PathType
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _storage_mixin as eti_storage
+from ensembl_tui import _util as eti_util
 
-compressor = compress(compressor=blosc2.compress2)
-decompressor = decompress(decompressor=blosc2.decompress2)
-pickler = pickle_it()
-unpickler = unpickle_it()
-inflate = decompressor + unpickler
+HOMOLOGY_ATTR_SCHEMA = (
+    "rowid INTEGER PRIMARY KEY DEFAULT nextval('rowid_seq')",
+    "homology_id INTEGER",
+    "stableid TEXT",
+    "species_db TEXT",
+    "homology_type TEXT",
+)
+HOMOLOGY_ATTR_COLS = eti_util.make_column_constant(HOMOLOGY_ATTR_SCHEMA)
 
 
 @dataclasses.dataclass(slots=True)

--- a/src/ensembl_tui/_ingest_homology.py
+++ b/src/ensembl_tui/_ingest_homology.py
@@ -9,22 +9,22 @@ from cogent3.app import typing as c3_types
 from cogent3.app.composable import LOADER, define_app
 
 from ensembl_tui import _config as eti_config
+from ensembl_tui import _homology as eti_homology
 from ensembl_tui import _ingest_annotation as eti_annotation
 from ensembl_tui import _util as eti_util
-from ensembl_tui._homology import homolog_group
 
-T = dict[str, tuple[homolog_group, ...]]
+T = dict[str, tuple[eti_homology.homolog_group, ...]]
 
 
 def grouped_related(
-    data: typing.Iterable[tuple[str, dict[str, str]]],
+    data: typing.Iterable[tuple[str, str, str, str, str]],
 ) -> T:
     """determines related groups of genes
 
     Parameters
     ----------
     data
-        list of full records from the HomologyDb
+        list of [(rel_type, sp1, gid1, sp2, gid2), ...]
 
     Returns
     -------
@@ -38,17 +38,15 @@ def grouped_related(
     # grouped is {<relationship type>: {gene id: homolog_group}. So gene's
     # that belong to the same group have the same value
     grouped = {}
-    for rel_type, gene_species in data:
+    for rel_type, sp1, gene_id_1, sp2, gene_id_2 in data:
         relationship = grouped.get(rel_type, {})
-        pair = gene_species.keys()
-        gene_id_1, gene_id_2 = pair
         if gene_id_1 in relationship:
             val = relationship[gene_id_1]
         elif gene_id_2 in relationship:
             val = relationship[gene_id_2]
         else:
-            val = homolog_group(relationship=rel_type)
-        val.gene_ids |= gene_species
+            val = eti_homology.homolog_group(relationship=rel_type)
+        val.gene_ids |= {gene_id_1: sp1, gene_id_2: sp2}
 
         relationship[gene_id_1] = relationship[gene_id_2] = val
         grouped[rel_type] = relationship
@@ -56,6 +54,21 @@ def grouped_related(
     return {
         rel_type: tuple(set(groups.values())) for rel_type, groups in grouped.items()
     }
+
+
+def merge_grouped(
+    groups: typing.Sequence[eti_homology.homolog_group],
+) -> tuple[eti_homology.homolog_group, ...]:
+    """merges grouped homology data"""
+    grouped = {}
+    for group in groups:
+        if present := group.gene_ids.keys() & grouped.keys():
+            val = grouped[next(iter(present))]
+            val.gene_ids |= group.gene_ids
+        else:
+            grouped |= {gene_id: group for gene_id in group.gene_ids}
+
+    return tuple(set(grouped.values()))
 
 
 @define_app(app_type=LOADER)
@@ -85,31 +98,18 @@ class load_homologies:  # noqa: N801
         conn = duckdb.connect(":memory:")
         sql = self._create_sql.format(path)
         conn.sql(sql)
-        return grouped_related(
-            (rel_type, {gene_1: sp_1, gene_2: sp_2})
-            for rel_type, sp_1, gene_1, sp_2, gene_2 in conn.sql(
-                self._select_sql,
-            ).fetchall()
-        )  # type: ignore
+        return grouped_related(conn.sql(self._select_sql).fetchall())
 
 
 class HomologyAggregator:
     def __init__(self, conn: duckdb.DuckDBPyConnection) -> None:
-        self._relationship_indexer = eti_util.unique_value_indexer()
-        self._species_indexer = eti_util.unique_value_indexer()
-        self._stableids_indexer = eti_util.unique_value_indexer()
-        self._homology_indexer = eti_util.category_indexer()
+        self._homology_id = 0
         self.conn = conn
-
-    def _make_stableid_id(self, *, stableid: str, species: str) -> int:
-        """returns the stableid.id value for (species,stableid)"""
-        species_id = self._species_indexer(species)
-        return self._stableids_indexer((species_id, stableid))
 
     def add_records(
         self,
         *,
-        records: typing.Sequence[homolog_group],
+        records: typing.Sequence[eti_homology.homolog_group],
         relationship_type: str,
     ) -> None:
         """inserts homology data from records
@@ -126,118 +126,42 @@ class HomologyAggregator:
             msg = f"invalid {relationship_type=!r}"
             raise ValueError(msg)
 
-        relationship_id = self._relationship_indexer(relationship_type)
-        homology_values = []
         values = []
-        for group in records:
+        for homology_id, group in enumerate(records, start=self._homology_id + 1):
             if group.relationship != relationship_type:
                 msg = f"{group.relationship=} != {relationship_type=}"
                 raise ValueError(msg)
 
             # get geneids and species for this group, storing the
             # geneid id for each record
-            gene_ids = {
-                self._make_stableid_id(stableid=gene_id, species=species)
-                for gene_id, species in group.gene_ids.items()
-            }
 
-            # now get the homology id for this group
-            homology_id = self._homology_indexer(relationship_id, gene_ids)
-            homology_values.append((homology_id, relationship_id))
-            values.extend([(int(gene_id), int(homology_id)) for gene_id in gene_ids])
+            values.extend(
+                [
+                    (homology_id, gene_id, species, relationship_type)
+                    for gene_id, species in group.gene_ids.items()
+                ],
+            )
 
+        # record last homology_index
+        self._homology_id = homology_id
         # create the homology table entries
+        placeholder = ", ".join("?" * (len(eti_homology.HOMOLOGY_ATTR_COLS) - 1))
+        cols = ", ".join(eti_homology.HOMOLOGY_ATTR_COLS[1:])
         sql = (
-            "INSERT OR IGNORE INTO homology(homology_id, relationship_id) VALUES (?, ?)"
+            f"INSERT OR IGNORE INTO homology_groups_attr({cols}) VALUES ({placeholder})"
         )
-        self.conn.executemany(sql, parameters=homology_values)
-        sql = "INSERT OR IGNORE INTO member(stableid_id, homology_id) VALUES (?, ?)"
         self.conn.executemany(sql, parameters=values)
-
-    def commit(self):
-        # add the indexes for species and relationships
-        relationships = list(self._relationship_indexer)
-        sql = "INSERT OR IGNORE INTO relationship(relationship_id, homology_type) VALUES (?,?)"
-        self.conn.executemany(sql, parameters=relationships)
-        species = list(self._species_indexer)
-        sql = "INSERT OR IGNORE INTO species(species_id, species_db) VALUES (?,?)"
-        self.conn.executemany(sql, parameters=species)
-        # now the same for stableids
-        stableids = [(index, *attr) for index, attr in self._stableids_indexer]
-        sql = "INSERT OR IGNORE INTO stableid(stableid_id, species_id, stableid) VALUES (?,?,?)"
-        self.conn.executemany(sql, parameters=stableids)
-        self.conn.commit()
 
 
 def make_homology_aggregator_db() -> HomologyAggregator:
-    defns = {
-        "relationship": {
-            "homology_type": "TEXT",
-            "relationship_id": "INTEGER PRIMARY KEY",
-        },
-        "homology": {
-            "homology_id": "INTEGER PRIMARY KEY DEFAULT nextval('homology_id_seq')",
-            "relationship_id": "INTEGER",
-        },
-        "species": {
-            "species_id": "INTEGER PRIMARY KEY",
-            "species_db": "TEXT",
-        },
-        "stableid": {
-            "stableid_id": "INTEGER PRIMARY KEY",
-            "stableid": "TEXT",
-            "species_id": "INTEGER",
-        },
-        "member": {  # gene membership of a specific homolog group
-            "member_id": "INTEGER PRIMARY KEY DEFAULT nextval('member_id_seq')",
-            "stableid_id": "INTEGER",
-            "homology_id": "INTEGER",
-        },
-    }
-
     conn = duckdb.connect(":memory:")
-    conn.sql("CREATE SEQUENCE homology_id_seq")
-    conn.sql("CREATE SEQUENCE member_id_seq")
-
-    for table_name, schema in defns.items():
-        columns = ", ".join(f"{k} {v}" for k, v in schema.items())
-        conn.sql(f"CREATE TABLE {table_name} ({columns})")
-
-    sql = """CREATE VIEW IF NOT EXISTS homology_member AS
-        SELECT h.homology_id as homology_id,
-               h.relationship_id as relationship_id,
-               r.homology_type as homology_type,
-               m.stableid_id as stableid_id
-        FROM homology h
-        JOIN relationship r ON h.relationship_id = r.relationship_id
-        JOIN member m ON m.homology_id = h.homology_id
-        """
-    conn.sql(sql)
-    # this view relates stabelids to species db names
-    # since that cannot be reliably inferred from the stableid
-    # naming scheme. Possibly just need the species_db and stableid columns?
-    sql = """CREATE VIEW IF NOT EXISTS gene_species_attr AS
-        SELECT sp.species_db as species_db,
-               sp.species_id as species_id,
-               st.stableid as stableid,
-               st.stableid_id as stableid_id
-        FROM species sp
-        JOIN stableid st ON st.species_id = sp.species_id
-        """
-    conn.sql(sql)
     # this view condenses the homology member data so that we can
     # query for a relationship type and get the stableid and species
     # bear in mind that for a given relationship type, I'm assuming
     # that a stableid can only belong to one homology group (homology_id)
-    sql = """
-        CREATE VIEW IF NOT EXISTS homology_groups_attr AS
-        SELECT gs.stableid as stableid,
-               gs.species_db as species_db,
-               hm.homology_id as homology_id,
-               hm.homology_type as homology_type
-        FROM gene_species_attr gs
-        JOIN homology_member hm ON hm.stableid_id = gs.stableid_id
-        """
+    conn.sql("CREATE SEQUENCE rowid_seq")
+    schema = ", ".join(eti_homology.HOMOLOGY_ATTR_SCHEMA)
+    sql = f"CREATE TABLE homology_groups_attr ({schema})"
     conn.sql(sql)
     return HomologyAggregator(conn)
 
@@ -264,7 +188,7 @@ def local_install_homology(
     if force_overwrite:
         shutil.rmtree(config.install_homologies, ignore_errors=True)
 
-    # config.install_homologies.mkdir(parents=True, exist_ok=True)
+    config.install_homologies.mkdir(parents=True, exist_ok=True)
 
     tsv_paths = []
     for sp in config.db_names:
@@ -285,5 +209,3 @@ def local_install_homology(
     for grouped in track(tasks, total=len(tsv_paths), description="aggregating"):
         for rel_type, records in grouped.items():
             agg.add_records(records=records, relationship_type=rel_type)
-
-    agg.commit()

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -156,8 +156,8 @@ def local_install_homology(
         if progress is not None:
             progress.update(load_homs, description=msg, advance=1)
 
-    # we merge the homology groups
     if progress is not None:
+        progress.remove_task(load_homs)
         msg = "Aggregating homologies"
         agg = progress.add_task(
             total=len(results),
@@ -166,6 +166,7 @@ def local_install_homology(
             transient=True,
         )
 
+    # we merge the homology groups
     for rel_type, records in results.items():
         results[rel_type] = homology_ingest.merge_grouped(records)
 
@@ -174,7 +175,8 @@ def local_install_homology(
 
     # write the homology groups to in-memory db
     if progress is not None:
-        msg = "Writing homologies"
+        progress.remove_task(agg)
+        msg = "Installing homologies"
         write = progress.add_task(total=len(results), description=msg, advance=0)
 
     db = homology_ingest.make_homology_aggregator_db()

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -282,11 +282,6 @@ def install(
             verbose=verbose,
             progress=progress,
         )
-        # On test cases, only 30% speedup from running install homology data
-        # in parallel due to overhead of pickling the data, but considerable
-        # increase in memory. So, run in serial to avoid memory issues since
-        # it's reasonably fast anyway. (At least until we have
-        # a more robust solution.)
         local_install_homology(
             config,
             force_overwrite=force_overwrite,

--- a/tests/test_homology.py
+++ b/tests/test_homology.py
@@ -233,6 +233,9 @@ def test_homdb_add_invalid_record():
     with pytest.raises(ValueError):
         agg.add_records(records=records, relationship_type="one2one")
 
+    with pytest.raises(ValueError):
+        agg.add_records(records=records, relationship_type=None)
+
 
 @pytest.mark.parametrize(
     "gene_id,rel_type",
@@ -287,6 +290,9 @@ def test_homdb_num_records(o2o_db):
     assert got.columns["count"][0] == 41
     got = homdb.count_distinct(species=True)
     assert got.shape == (9, 2)
+    got = homdb.num_records()
+    # from inspecting the original data we expect 5
+    assert got == 5
 
 
 @pytest.fixture

--- a/tests/test_homology.py
+++ b/tests/test_homology.py
@@ -55,7 +55,6 @@ def o2o_db(DATA_DIR, tmp_dir):
     hom_groups = loader(raw)  # pylint: disable=not-callable
     for rel_type, data in hom_groups.items():
         agg.add_records(records=data, relationship_type=rel_type)
-    agg.commit()
     homol_ingest.write_homology_views(agg=agg, outdir=tmp_dir)
     homdb = eti_homology.HomologyDb(source=tmp_dir)
     return homdb, table
@@ -63,13 +62,13 @@ def o2o_db(DATA_DIR, tmp_dir):
 
 @pytest.mark.parametrize(
     "gene_id",
-    (
+    [
         "ENSGGOG00000026757",
         "ENSGGOG00000025053",
         "ENSGGOG00000022688",
         "ENSGGOG00000026221",
         "ENSGGOG00000024015",
-    ),
+    ],
 )
 def test_hdb(o2o_db, gene_id):
     homdb, table = o2o_db
@@ -82,15 +81,15 @@ def test_hdb(o2o_db, gene_id):
 @pytest.fixture
 def orth_records():
     return [
-        ("ortholog_one2one", {"1": "sp1", "2": "sp2"}),  # grp 1
-        ("ortholog_one2one", {"2": "sp2", "3": "sp3"}),  # grp 1
-        ("ortholog_one2one", {"4": "sp1", "5": "sp3"}),
+        ("ortholog_one2one", "sp1", "1", "sp2", "2"),  # grp 1
+        ("ortholog_one2one", "sp2", "2", "sp3", "3"),  # grp 1
+        ("ortholog_one2one", "sp1", "4", "sp3", "5"),  # grp 2
     ]
 
 
 @pytest.fixture
 def hom_records(orth_records):
-    return orth_records + [("ortholog_one2many", {"6": "sp2", "7": "sp3"})]
+    return [*orth_records, ("ortholog_one2many", "sp2", "6", "sp3", "7")]  # grp 3
 
 
 def test_hdb_get_related_groups(o2o_db):
@@ -105,7 +104,6 @@ def hom_hdb(hom_records, tmp_dir):
     agg = homol_ingest.make_homology_aggregator_db()
     for rel_type, data in groups.items():
         agg.add_records(records=data, relationship_type=rel_type)
-    agg.commit()
     homol_ingest.write_homology_views(agg=agg, outdir=tmp_dir)
     return eti_homology.HomologyDb(source=tmp_dir)
 

--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -45,4 +45,4 @@ def test_get_genes(small_install_path):
 def test_installed_genomes(small_install_path):
     config = eti_config.read_installed_cfg(small_install_path)
     got = config.list_genomes()
-    assert got == ["caenorhabditis_elegans", "saccharomyces_cerevisiae"]
+    assert set(got) == {"caenorhabditis_elegans", "saccharomyces_cerevisiae"}


### PR DESCRIPTION
[CHANGED] split the homology installation into loading, aggregating, and
    writing. This does increase memory footprint, but it greatly improves
    performance.

[CHANGED] HomologyAggregator.add_record() directly inserts into the
    homology_groups_attr table. We now assume the input records are in
    their final form. This means we can delete nearly all attributes
    and methods. It also means we no longer need the
    HomologyAggregator.commit() method.

[CHANGED] _ingest_homology.group_related() takes raw data from sql query,
    which significantly improves performance

[NEW] _ingest_homology.merge_grouped() allows us to merge the homolog_group
    data in python, rather than looking things up in duckdb -- significant
    performance improvement

[CHANGED] don't compress result of load_homologies based on whether running
    in multiprocess mode. Has little benefit in terms of memory footprint.
    Revisit this issue later.

## Summary by Sourcery

Refactor homology installation to improve performance by splitting the process into loading, aggregating, and writing. Directly insert records into the database, simplifying the `HomologyAggregator` and removing the need for a `commit` method. Merge homolog group data in Python for a significant performance boost.

Enhancements:
- Load raw data from SQL queries and merge grouped homology data in Python instead of using DuckDB lookups, significantly improving performance.

Tests:
- Update tests to reflect changes in homology data handling.