### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -289,6 +289,7 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         **kwargs,  # noqa: ANN003
     ) -> typing.Iterator[FeatureDataBase]:
         # add supoport for querying by symbol and description
+        stable_id = stable_id or kwargs.pop("name", None)
         limit = kwargs.pop("limit", None)
         local_vars = locals()
         if kwargs := {

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -294,7 +294,8 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         if kwargs := {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "columns", "limit") and v is not None
+            if k not in ("self", "kwargs", "columns", "limit", "local_vars")
+            and v is not None
         }:
             like_conds = (
                 {"description": kwargs.pop("description")} if description else None
@@ -592,7 +593,7 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         if kwargs := {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "limit") and v is not None
+            if k not in ("self", "kwargs", "limit", "local_vars") and v is not None
         }:
             like_cols = "repeat_type", "repeat_class", "repeat_name"
             like_conds = {k: v for k, v in kwargs.items() if k in like_cols}

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -424,11 +424,22 @@ class Genome:
 
     def get_ids_for_biotype(
         self,
+        *,
         biotype: str,
+        seqid: str | list[str] | None = None,
         limit: OptionalInt = None,
     ) -> typing.Iterable[str]:
         genes = self.annotation_db.genes
-        return genes.get_ids_for_biotype(biotype=biotype, limit=limit)
+        if genes is None:
+            msg = f"no gene data for {self.species}"
+            raise ValueError(msg)
+        seqids = [seqid] if isinstance(seqid, str | type(None)) else seqid
+        for seqid in seqids:
+            yield from genes.get_ids_for_biotype(
+                biotype=biotype,
+                seqid=seqid,
+                limit=limit,
+            )
 
     def close(self) -> None:
         self._seqs.close()

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -374,7 +374,7 @@ class Genome:
         for ft in self.annotation_db.get_features_matching(
             biotype=biotype,
             seqid=seqid,
-            name=name,
+            stable_id=name,
             start=start,
             stop=stop,
             limit=limit,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,8 +111,8 @@ def test_dump_genes(installed):
 
 
 @pytest.mark.slow
-def test_homologs(installed):
-    outdir = installed.parent / "output"
+def test_homologs(installed, tmp_dir):
+    outdir = tmp_dir / "output"
     limit = 10
     args = [
         f"-i{installed}",
@@ -122,6 +122,35 @@ def test_homologs(installed):
         f"{outdir}",
         "--limit",
         str(limit),
+        "-r",
+        "ortholog_one2one",
+        "-v",
+    ]
+
+    r = RUNNER.invoke(
+        eti_cli.homologs,
+        args,
+        catch_exceptions=False,
+    )
+    assert r.exit_code == 0, r.output
+    dstore = cogent3.open_data_store(outdir, suffix="fa", mode="r")
+    assert len(dstore.completed) == limit
+
+
+@pytest.mark.slow
+def test_homologs_coord_name(installed, tmp_dir):
+    outdir = tmp_dir / "output"
+    limit = 10
+    args = [
+        f"-i{installed}",
+        "--ref",
+        "saccharomyces_cerevisiae",
+        "--outdir",
+        f"{outdir}",
+        "--limit",
+        str(limit),
+        "--coord_names",
+        "I,XVI,II",
         "-r",
         "ortholog_one2one",
         "-v",

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -172,3 +172,18 @@ def test_get_features(yeast):
 def test_get_ids_for_biotype(yeast):
     features = list(yeast.get_ids_for_biotype(biotype="rRNA", limit=10))
     assert len(features) == 10
+
+
+def test_get_ids_for_biotype_seqid(yeast):
+    stable_ids = list(yeast.get_ids_for_biotype(biotype="protein_coding", seqid="III"))
+    assert len(stable_ids) == 184  # from direct inspection of sql count distinct
+    stable_ids = list(
+        yeast.get_ids_for_biotype(biotype="protein_coding", seqid=["III", "XVI"]),
+    )
+    assert len(stable_ids) == 184 + 511  # from direct inspection of sql count distinct
+    # make sure the seqid match the input
+    seqids = {"III", "XVI"}
+    got = {
+        r.seqid for stable_id in stable_ids for r in yeast.get_features(name=stable_id)
+    }
+    assert got == seqids


### PR DESCRIPTION
## Summary by Sourcery

Add the ability to specify reference coordinates when retrieving homologs.

New Features:
- Allow users to specify a list of chromosome/scaffold names to limit the homolog search.

Tests:
- Added tests to verify that the homolog retrieval respects the specified coordinates.