### PR TITLE
MAINT: mixed patches

### DIFF
--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -17,7 +17,7 @@ DNA = cogent3.get_moltype("dna", new_type=True)
 
 _no_gaps = numpy.array([], dtype=_DEFAULT_GAP_DTYPE)
 
-ALIGN_STORE_SUFFIX = "align_coords-sqlitedb"
+ALIGN_STORE_SUFFIX = "parquet"
 
 ALIGN_ATTR_SCHEMA = (
     "align_id INTEGER PRIMARY KEY DEFAULT nextval('align_id_seq')",

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -200,11 +200,16 @@ class InstalledConfig:
         pattern
             glob pattern for the Ensembl alignment name
         """
-        align_dirs = [
-            d
-            for d in self.aligns_path.glob("*")
-            if fnmatch.fnmatch(d.stem, pattern) and d.name.endswith(suffix)
-        ]
+        if eti_util.contains_glob_pattern(pattern):
+            align_dirs = [
+                d
+                for d in self.aligns_path.glob("*")
+                if fnmatch.fnmatch(d.name, pattern)
+            ]
+        elif pattern:
+            align_dirs = [d for d in self.aligns_path.glob("*") if pattern in d.name]
+        else:
+            align_dirs = None
         if not align_dirs:
             return None
 
@@ -214,7 +219,11 @@ class InstalledConfig:
                 msg,
             )
 
-        return align_dirs[0]
+        align_dir = align_dirs[0]
+        if not list(align_dir.glob(f"*{suffix}")):
+            msg = f"{align_dir} does not contain file with suffix {suffix}"
+            raise FileNotFoundError(msg)
+        return align_dir
 
 
 def write_installed_cfg(config: Config) -> eti_util.PathType:

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -571,3 +571,10 @@ def tempdir(working_dir: pathlib.Path | str | None = None) -> pathlib.Path:
 
 def make_column_constant(schema: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(c.split()[0] for c in schema)
+
+
+_has_wildcard = re.compile(r"[*?\[\]]")
+
+
+def contains_glob_pattern(s: str) -> bool:
+    return _has_wildcard.search(s) is not None

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -387,6 +387,7 @@ def species_summary(installed, species):
 @_outdir
 @_align_name
 @_ref
+@_coord_names
 @_ref_genes_file
 @_mask_features
 @_limit
@@ -397,6 +398,7 @@ def alignments(
     outdir,
     align_name,
     ref,
+    coord_names,
     ref_genes_file,
     mask_features,
     limit,
@@ -430,6 +432,14 @@ def alignments(
             text=f"{align_name!r} does not match any alignments under {str(config.aligns_path)!r}",
             colour="red",
         )
+        available = "\n".join(
+            [
+                fn.stem
+                for fn in config.aligns_path.glob("*")
+                if not fn.name.startswith(".") and fn.is_dir()
+            ],
+        )
+        eti_util.print_colour(text=f"Available alignments:\n{available}", colour="red")
         sys.exit(1)
 
     align_db = eti_align.AlignDb(source=align_path)
@@ -463,6 +473,14 @@ def alignments(
             )
             sys.exit(1)
         stableids = table.columns["stableid"]
+    elif coord_names:
+        genome = genomes[ref_species]
+        stableids = list(
+            genome.get_ids_for_biotype(
+                biotype="protein_coding",
+                seqid=coord_names,
+            ),
+        )
     else:
         stableids = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,7 +73,7 @@ def test_get_alignment_path_incomplete(incomplete_installed):
         incomplete_installed.path_to_alignment("10*", eti_align.ALIGN_STORE_SUFFIX)
 
 
-@pytest.mark.parametrize("pattern", ("10pri*", "blah-blah", "")[-1:])
+@pytest.mark.parametrize("pattern", ["10pri*", "blah-blah", ""])
 def test_get_alignment_path_invalid(installed_aligns, pattern):
     assert (
         installed_aligns.path_to_alignment(pattern, eti_align.ALIGN_STORE_SUFFIX)
@@ -81,7 +81,7 @@ def test_get_alignment_path_invalid(installed_aligns, pattern):
     )
 
 
-@pytest.mark.parametrize("pattern", ("*pri*", "*epo*"))
+@pytest.mark.parametrize("pattern", ["*pri*", "*epo*"])
 def test_get_alignment_path_multiple(installed_aligns, pattern):
     with pytest.raises(ValueError):
         installed_aligns.path_to_alignment(pattern, eti_align.ALIGN_STORE_SUFFIX)


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces new features and fixes bugs related to alignment handling. It adds the ability to filter alignments by coordinate names, fixes a crash when an alignment path is incomplete, improves alignment path resolution, and updates the alignments command to display available alignments. It also changes the alignment store suffix to 'parquet'.

New Features:
- Added the ability to specify coordinate names to filter alignments by stable IDs.

Bug Fixes:
- Fixed an issue where the application would crash if an alignment path was incomplete.

Enhancements:
- Improved alignment path resolution by considering directory names instead of file stems.
- Updated the alignments command to display available alignments when the specified alignment name does not match any existing alignments.

Chores:
- Changed the alignment store suffix from 'align_coords-sqlitedb' to 'parquet'.