### PR TITLE
ENH: use the limit argument in selecting genes for alignment command

### DIFF
--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -479,6 +479,7 @@ def alignments(
             genome.get_ids_for_biotype(
                 biotype="protein_coding",
                 seqid=coord_names,
+                limit=limit,
             ),
         )
     else:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- The `limit` argument is now used when selecting genes for the alignment command, allowing users to limit the number of genes used in the alignment.