### PR TITLE
ENH: display repeat info plus other cli improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ Some commands can be run in parallel but have moderate memory requirements. If y
 
   Options:
     -c, --configpath PATH  Path to config file specifying databases, (only species
-                           or compara at present).  [default:
-                           /Users/gavin/miniconda3/envs/eti/lib/python3.12/site-
-                           packages/ensembl_tui/data/sample.cfg]
+                           or compara at present).
     -d, --debug            Maximum verbosity, and reduces number of downloads,
                            etc...
     -v, --verbose

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Some commands can be run in parallel but have moderate memory requirements. If y
 
   Options:
     -c, --configpath PATH  Path to config file specifying databases, (only species
-                           or compara at present).
+                           or compara at present).  [default:
+                           /Users/gavin/miniconda3/envs/eti/lib/python3.12/site-
+                           packages/ensembl_tui/data/sample.cfg]
     -d, --debug            Maximum verbosity, and reduces number of downloads,
                            etc...
     -v, --verbose
@@ -227,6 +229,7 @@ We provide a conventional command line interface for querying the data with subc
 
   Commands:
     alignments       export multiple alignments in fasta format for named genes
+    compara-summary  summary data for compara
     download         download data from Ensembl's ftp site
     dump-genes       export meta-data table for genes from one species to...
     exportrc         exports sample config and species table to the nominated...

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -253,7 +253,6 @@ class BiotypeView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         sql = f"SELECT DISTINCT biotype FROM {self._tables[0]}"
         return tuple(r[0] for r in self.conn.sql(sql).fetchall())
 
-    @functools.cached_property
     def count_distinct(self) -> "Table":
         sql = (
             f"SELECT biotype, COUNT(*) AS freq FROM {self._tables[0]} GROUP BY biotype"

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -627,3 +627,32 @@ def get_species_gene_summary(
     counts.title = f"{common_name} features"
     counts.format_column("count", lambda x: f"{x:,}")
     return counts
+
+
+def get_species_repeat_summary(
+    *,
+    annot_db: eti_annots.Annotations,
+    species: str | None = None,
+) -> Table:
+    """
+    returns the Table summarising repeat data for species_name
+
+    Parameters
+    ----------
+    annot_db
+        feature db
+    species
+        species name, overrides inference from annot_db.source
+    """
+    # for now, just biotype
+    species = species or annot_db.source.parent.name
+    counts = annot_db.repeats.count_distinct(repeat_class=True, repeat_type=True)
+    try:
+        common_name = eti_species.Species.get_common_name(species)
+    except ValueError:
+        common_name = species
+
+    counts = counts.sorted(columns=["repeat_type", "count"])
+    counts.title = f"{common_name} repeat"
+    counts.format_column("count", lambda x: f"{x:,}")
+    return counts

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -601,7 +601,7 @@ def get_gene_table_for_species(
     return table
 
 
-def get_species_summary(
+def get_species_gene_summary(
     *,
     annot_db: eti_annots.Annotations,
     species: str | None = None,
@@ -618,7 +618,7 @@ def get_species_summary(
     """
     # for now, just biotype
     species = species or annot_db.source.parent.name
-    counts = annot_db.biotypes.count_distinct
+    counts = annot_db.biotypes.count_distinct()
     try:
         common_name = eti_species.Species.get_common_name(species)
     except ValueError:

--- a/src/ensembl_tui/_homology.py
+++ b/src/ensembl_tui/_homology.py
@@ -14,6 +14,9 @@ from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
 
+if typing.TYPE_CHECKING:
+    from cogent3.util.table import Table
+
 HOMOLOGY_ATTR_SCHEMA = (
     "rowid INTEGER PRIMARY KEY DEFAULT nextval('rowid_seq')",
     "homology_id INTEGER",
@@ -150,7 +153,11 @@ class HomologyDb(eti_storage.DuckdbParquetBase):
         sql = "SELECT COUNT(DISTINCT homology_id) FROM homology_groups_attr"
         return self.conn.sql(sql).fetchone()[0]
 
-    def count_distinct(self, species: bool = False, homology_type: bool = False) -> int:
+    def count_distinct(
+        self,
+        species: bool = False,
+        homology_type: bool = False,
+    ) -> "Table":
         columns = []
         if species:
             columns.append("species_db")

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -493,9 +493,9 @@ class _printer:  # noqa: N801
     def __init__(self) -> None:
         self._console = self.Console()
 
-    def __call__(self, text: str, colour: str) -> None:
+    def __call__(self, text: str, colour: str, style: str = "") -> None:
         """print text in colour"""
-        msg = rich_text.Text(text)
+        msg = rich_text.Text(text, style=style)
         msg.stylize(colour)
         self._console.print(msg)
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -394,6 +394,22 @@ def species_summary(installed: pathlib.Path, species: str) -> None:
 
 @main.command(**_click_command_opts)
 @_installed
+def compara_summary(installed: pathlib.Path) -> None:
+    """summary data for compara"""
+
+    config = eti_config.read_installed_cfg(installed)
+    if config.homologies_path.exists():
+        db = eti_homology.load_homology_db(
+            path=config.homologies_path,
+        )
+        table = db.count_distinct(homology_type=True)
+        table.title = "Homology types"
+        table.format_column("count", lambda x: f"{x:,}")
+        eti_util.rich_display(table)
+
+
+@main.command(**_click_command_opts)
+@_installed
 @_outdir
 @_align_name
 @_ref

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -73,7 +73,6 @@ _click_command_opts = {
 _cfgpath = click.option(
     "-c",
     "--configpath",
-    default=eti_download.DEFAULT_CFG,
     type=pathlib.Path,
     help="Path to config file specifying databases, (only "
     "species or compara at present).",
@@ -209,12 +208,14 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
     """download data from Ensembl's ftp site"""
     from rich import progress
 
-    if configpath.name == eti_download.DEFAULT_CFG:
-        # TODO is this statement correct if we're seting a root dir now?
+    if not configpath:
         eti_util.print_colour(
-            text="WARN: using the built in demo cfg, will write to /tmp",
-            colour="yellow",
+            text="No config specified, exiting.",
+            colour="red",
+            style="bold",
         )
+        sys.exit(1)
+
     config = eti_config.read_config(configpath, root_dir=pathlib.Path.cwd())
 
     if verbose:

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -27,7 +27,7 @@ def _get_coord_names(ctx, param, coord_names) -> list[str] | None:
     return [f.strip() for f in coord_names.split(",")]
 
 
-def _get_installed_config_path(ctx, param, path) -> eti_util.PathType:
+def _get_installed_config_path(ctx, param, path) -> pathlib.Path:
     """path to installed.cfg"""
     path = pathlib.Path(path)
     if path.name == eti_config.INSTALLED_CONFIG_NAME:
@@ -183,7 +183,7 @@ def main():
 
 @main.command(**_click_command_opts)
 @_dbrc_out
-def exportrc(outpath):
+def exportrc(outpath: pathlib.Path) -> None:
     """exports sample config and species table to the nominated path"""
 
     outpath = outpath.expanduser()
@@ -204,7 +204,7 @@ def exportrc(outpath):
 @_cfgpath
 @_debug
 @_verbose
-def download(configpath, debug, verbose):
+def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
     """download data from Ensembl's ftp site"""
     from rich import progress
 
@@ -323,7 +323,7 @@ def install(
 
 @main.command(**_click_command_opts)
 @_installed
-def installed(installed):
+def installed(installed: pathlib.Path) -> None:
     """show what is installed"""
     from cogent3 import make_table
 
@@ -359,7 +359,7 @@ def installed(installed):
 @main.command(**_click_command_opts)
 @_installed
 @_species
-def species_summary(installed, species):
+def species_summary(installed: pathlib.Path, species: str) -> None:
     """genome summary data for a species"""
 
     config = eti_config.read_installed_cfg(installed)
@@ -394,17 +394,17 @@ def species_summary(installed, species):
 @_force
 @_verbose
 def alignments(
-    installed,
-    outdir,
-    align_name,
-    ref,
-    coord_names,
-    ref_genes_file,
-    mask_features,
-    limit,
-    force_overwrite,
-    verbose,
-):
+    installed: pathlib.Path,
+    outdir: pathlib.Path,
+    align_name: str,
+    ref: str,
+    coord_names: str,
+    ref_genes_file: pathlib.Path,
+    mask_features: pathlib.Path,
+    limit: int,
+    force_overwrite: bool,
+    verbose: bool,
+) -> None:
     """export multiple alignments in fasta format for named genes"""
     from cogent3 import load_table
     from rich import progress
@@ -546,16 +546,16 @@ def alignments(
 @_force
 @_verbose
 def homologs(
-    installed,
-    outdir,
-    relationship,
-    ref,
-    coord_names,
-    num_procs,
-    limit,
-    force_overwrite,
-    verbose,
-):
+    installed: pathlib.Path,
+    outdir: pathlib.Path,
+    relationship: str,
+    ref: str,
+    coord_names: str,
+    num_procs: int,
+    limit: int,
+    force_overwrite: bool,
+    verbose: bool,
+) -> None:
     """exports CDS sequence data in fasta format for homology type relationship"""
     from rich import progress
 
@@ -671,7 +671,12 @@ def homologs(
 @_species
 @_outdir
 @_limit
-def dump_genes(installed, species, outdir, limit):
+def dump_genes(
+    installed: pathlib.Path,
+    species: str,
+    outdir: pathlib.Path,
+    limit: int,
+) -> None:
     """export meta-data table for genes from one species to <species>-<release>.gene_metadata.tsv"""
 
     config = eti_config.read_installed_cfg(installed)

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -378,7 +378,9 @@ def species_summary(installed: pathlib.Path, species: str) -> None:
     annot_db = eti_genome.load_annotations_for_species(
         path=config.installed_genome(species=species),
     )
-    summary = eti_genome.get_species_summary(annot_db=annot_db, species=species)
+    summary = eti_genome.get_species_gene_summary(annot_db=annot_db, species=species)
+    eti_util.rich_display(summary)
+    summary = eti_genome.get_species_repeat_summary(annot_db=annot_db, species=species)
     eti_util.rich_display(summary)
 
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -11,6 +11,7 @@ from ensembl_tui import __version__
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _download as eti_download
 from ensembl_tui import _genome as eti_genome
+from ensembl_tui import _homology as eti_homology
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
@@ -340,8 +341,11 @@ def installed(installed: pathlib.Path) -> None:
             data["species"].append(name)
             data["common name"].append(cn)
 
-        table = make_table(data=data, title="Installed genomes")
+        table = make_table(data=data, title="Installed genomes:")
         eti_util.rich_display(table)
+
+    if config.homologies_path.exists():
+        eti_util.print_colour("Installed homologies: ✅", colour="blue", style="bold")
 
     # TODO as above
     compara_aligns = config.aligns_path
@@ -349,9 +353,13 @@ def installed(installed: pathlib.Path) -> None:
         align_names = {
             fn.stem for fn in compara_aligns.glob("*") if not fn.name.startswith(".")
         }
+        eti_util.print_colour(
+            "Installed whole genome alignments:",
+            colour="blue",
+            style="bold",
+        )
         table = make_table(
             data={"align name": list(align_names)},
-            title="Installed whole genome alignments",
         )
         eti_util.rich_display(table)
 
@@ -560,8 +568,6 @@ def homologs(
 ) -> None:
     """exports CDS sequence data in fasta format for homology type relationship"""
     from rich import progress
-
-    from ensembl_tui import _homology as eti_homology
 
     LOGGER = CachingLogger()
     LOGGER.log_args()

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -43,7 +43,7 @@ def test_biotype_view(worm_biotypes):
     distinct = bt.distinct
     assert "protein_coding" in distinct
     assert "miRNA" in distinct
-    counts = bt.count_distinct
+    counts = bt.count_distinct()
     assert counts["protein_coding", "count"] > 10_000
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,3 +164,15 @@ def test_homologs_coord_name(installed, tmp_dir):
     assert r.exit_code == 0, r.output
     dstore = cogent3.open_data_store(outdir, suffix="fa", mode="r")
     assert len(dstore.completed) == limit
+
+
+@pytest.mark.slow
+def test_compara_summary(installed):
+    r = RUNNER.invoke(
+        eti_cli.compara_summary,
+        [f"-i{installed}"],
+        catch_exceptions=False,
+    )
+    assert r.exit_code == 0, r.output
+    assert "homology_type" in r.output
+    assert "ortholog_one2many" in r.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,12 @@ def test_download(tmp_config):
     assert r.exit_code == 0, r.output
 
 
+def test_download_no_config():
+    r = RUNNER.invoke(eti_cli.download, ["-d"], catch_exceptions=False)
+    assert r.exit_code != 0, r.output
+    assert "No config" in r.output
+
+
 def test_exportrc(tmp_dir):
     """exportrc works correctly"""
     outdir = tmp_dir / "exported"

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -44,6 +44,17 @@ def test_get_species_gene_summary(yeast_db):
     # we do not check values here, only the Type and that we have > 0 records
     assert isinstance(got, Table)
     assert len(got) > 0
+    assert "biotype" in got.header
+
+
+def test_get_species_repeat_summary(yeast_db):
+    from cogent3.util.table import Table
+
+    got = eti_genome.get_species_repeat_summary(annot_db=yeast_db)
+    # we do not check values here, only the Type and that we have > 0 records
+    assert isinstance(got, Table)
+    assert len(got) > 0
+    assert "repeat_type" in got.header
 
 
 def test_genome_coord_names(yeast_db):

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -37,10 +37,10 @@ def test_get_gene_table_for_species(yeast_db):
     assert len(got) > 0
 
 
-def test_get_species_summary(yeast_db):
+def test_get_species_gene_summary(yeast_db):
     from cogent3.util.table import Table
 
-    got = eti_genome.get_species_summary(annot_db=yeast_db)
+    got = eti_genome.get_species_gene_summary(annot_db=yeast_db)
     # we do not check values here, only the Type and that we have > 0 records
     assert isinstance(got, Table)
     assert len(got) > 0


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces several CLI improvements, including displaying repeat information in species summaries, adding a new command for summarizing compara data, and enhancing the `installed` command output. It also updates the CLI to use `pathlib.Path` for file paths.

New Features:
- Adds a `compara-summary` command to display summary data for compara, including counts of distinct homology types.

Enhancements:
- Improves the `installed` command output to indicate the presence of installed homologies.
- The `species_summary` command now displays repeat information in addition to gene summaries.
- The CLI now uses `pathlib.Path` for file paths, improving type safety and consistency.

Tests:
- Adds a test case for the new `compara_summary` command.
- Adds a test case for the `get_species_repeat_summary` function.