### PR TITLE
MAINT: code tidy

### DIFF
--- a/src/ensembl_tui/_mysql_core_attr.py
+++ b/src/ensembl_tui/_mysql_core_attr.py
@@ -73,9 +73,7 @@ def load_db(db_name: pathlib.Path, table_names: set[str]) -> duckdb.DuckDBPyConn
 
 
 location_attrs = {
-    # "coord_names": "coord_system",
     "location": "seq_region",
-    # "meta": "meta",
 }
 gene_attrs = {
     "stableid": "gene",
@@ -214,7 +212,7 @@ class TranscriptAttrRecord:
     def stop(self) -> int:
         return self.transcript_spans.max()
 
-    def to_record(self, columns: tuple[str]) -> tuple:
+    def to_record(self, columns: tuple[str, ...]) -> tuple:
         cds_blob = (
             eti_storage.array_to_blob(self.cds_spans)
             if self.cds_spans is not None
@@ -418,6 +416,3 @@ def make_gene_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
         """
     con.sql(sql)
     return con
-
-
-# the repeat and location related tables are left as is

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,7 +102,7 @@ def test_check_one_cds_seq(installed):
         "CAATTTTTGACCAAGGACTTGAAATTCCCATTGCCTCACAGAGTCCAAAAATCCACCAAG"
         "ACTTTCTCCTACAAGAGACCTTCCACTTTCTACTGA"
     )
-    assert str(cds.get_slice()) == expect
+    assert str(seq) == expect
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary by Sourcery

This PR performs minor code tidying, including removing unused code and standardising type annotations.