### PR TITLE
DEV: pinned ruff 0.10.0 and applied to code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "pytest-cov",
     "pytest-timeout",
     "pytest-xdist",
-    "ruff==0.9.7",
+    "ruff==0.10.0",
     "nox"]
 doc  = ["click",
         "sphinx",

--- a/src/ensembl_tui/_ingest_homology.py
+++ b/src/ensembl_tui/_ingest_homology.py
@@ -63,7 +63,7 @@ def merge_grouped(
             val = grouped[next(iter(present))]
             val.gene_ids |= group.gene_ids
         else:
-            grouped |= {gene_id: group for gene_id in group.gene_ids}
+            grouped |= dict.fromkeys(group.gene_ids, group)
 
     return tuple(set(grouped.values()))
 

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -552,7 +552,7 @@ class category_indexer:  # noqa: N801
             self._index += 1
             index = self._index
             new_vals = vals
-        entries |= {val: index for val in new_vals}
+        entries |= dict.fromkeys(new_vals, index)
         self._values[category] = entries
         return index
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -451,7 +451,7 @@ def test_align_db_get_records_no_matches(coord):
     # no hits at all
     _, align_db = make_sample()
     got = list(align_db.get_records_matching(**kwargs))
-    assert not len(got)
+    assert not got
 
 
 def test_get_species():

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -89,7 +89,7 @@ def test_repeat_view_count_distinct(worm_repeats):
 def test_create_genome(genome_dir):
     g = gen_pqt.Annotations(source=genome_dir)
     prot = list(g.get_features_matching(biotype="protein_coding"))
-    assert len(prot)
+    assert prot
 
 
 def test_get_feature_by_symbol(genome_dir):


### PR DESCRIPTION
## Summary by Sourcery

Updates ruff version to 0.10.0 and applies its formatting and linting rules to the codebase. Also, fixes a bug where the length of a list was being checked instead of the list itself.

Bug Fixes:
- Fixes a bug where the length of a list was being checked instead of the list itself, which could lead to incorrect boolean evaluation in tests and homology merging.
- Use dict.fromkeys to avoid iterating over the same values multiple times when merging homology groups and indexing values.