### PR TITLE
ENH: enable support for queries involving repeats

### DIFF
--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -9,6 +9,7 @@ from cogent3.app.composable import define_app
 from cogent3.core import new_alignment as c3_align
 from cogent3.core.location import _DEFAULT_GAP_DTYPE, IndelMap
 
+from ensembl_tui import _annotation as eti_ann
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
@@ -274,6 +275,9 @@ def get_alignment(
 
         seqs = {}
         gaps = {}
+        offsets = {}
+        seqid_species = {}
+        ann_dbs = {}
         for align_record in block:
             record_species = align_record.species
             genome = genomes[record_species]
@@ -315,16 +319,27 @@ def get_alignment(
 
             if s.name in seqs:
                 print(f"duplicated {s.name}")
+
             seqs[s.name] = numpy.array(s)
             gaps[s.name] = imap.array
+            offsets[s.name] = genome_start + seq_start
+            seqid_species[s.name] = eti_ann.get_species_seqid(
+                species=record_species,
+                seqid=align_record.seqid,
+            )
+            ann_dbs[record_species] = genome.annotation_db
 
         aln_data = c3_align.AlignedSeqsData.from_seqs_and_gaps(
             seqs=seqs,
             gaps=gaps,
             alphabet=DNA.most_degen_alphabet(),
+            offset=offsets,
         )
         aln = c3_align.Alignment(seqs_data=aln_data, moltype=DNA)
-        aln.annotation_db = genome.annotation_db
+        aln.annotation_db = eti_ann.MultispeciesAnnotations(
+            name_map=seqid_species,
+            species_annotations=ann_dbs,
+        )
         if mask_features:
             aln = aln.with_masked_annotations(biotypes=mask_features)
 

--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -214,6 +214,7 @@ def get_alignment(
     ref_end: int | None = None,
     namer: typing.Callable | None = None,
     mask_features: list[str] | None = None,
+    shadow: bool = False,
 ) -> typing.Iterable[c3_align.Alignment]:
     """yields cogent3 Alignments"""
 
@@ -341,7 +342,7 @@ def get_alignment(
             species_annotations=ann_dbs,
         )
         if mask_features:
-            aln = aln.with_masked_annotations(biotypes=mask_features)
+            aln = aln.with_masked_annotations(biotypes=mask_features, shadow=shadow)
 
         yield aln
 
@@ -359,11 +360,13 @@ class construct_alignment:  # noqa: N801
         align_db: AlignDb,
         genomes: dict[str, eti_genome.Genome],
         mask_features: list[str] | None = None,
+        shadow: bool = False,
         sep: str = "?",
     ) -> None:
         self._align_db = align_db
         self._genomes = genomes
         self._mask_features = mask_features
+        self._shadow = shadow
         self._sep = sep
 
     def main(self, segment: eti_genome.genome_segment) -> list[c3_align.Alignment]:
@@ -376,6 +379,7 @@ class construct_alignment:  # noqa: N801
             segment.start,
             segment.stop,
             mask_features=self._mask_features,
+            shadow=self._shadow,
         ):
             aln.info.source = segment.source
             results.append(aln)

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -761,3 +761,67 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
         self.biotypes.close()
         self.genes.close()
         self.repeats.close()
+
+
+@dataclasses.dataclass(frozen=True)
+class species_seqid:
+    species: str
+    seqid: str
+
+
+@functools.cache
+def get_species_seqid(*, species: str, seqid: str) -> species_seqid:
+    return species_seqid(species, seqid)
+
+
+@dataclasses.dataclass
+class MultispeciesAnnotations(AnnotationDbABC):
+    name_map: dict[str, species_seqid]
+    species_annotations: dict[str, Annotations]
+
+    def __len__(self) -> int:
+        return sum(len(ann) for ann in self.species_annotations.values())
+
+    def get_features_matching(self, seqid: str, **kwargs):
+        sp_sid = self.name_map[seqid]
+        db = self.species_annotations[sp_sid.species]
+        return db.get_features_matching(seqid=sp_sid.seqid, **kwargs)
+
+    def get_feature_children(self, seqid: str, **kwargs):
+        sp_sid = self.name_map[seqid]
+        db = self.species_annotations[sp_sid.species]
+        return db.get_feature_children(seqid=sp_sid.seqid, **kwargs)
+
+    def get_feature_parent(self, seqid: str, **kwargs):
+        sp_sid = self.name_map[seqid]
+        db = self.species_annotations[sp_sid.species]
+        return db.get_feature_parent(seqid=sp_sid.seqid, **kwargs)
+
+    def num_matches(self, seqid: str, **kwargs):
+        sp_sid = self.name_map[seqid]
+        db = self.species_annotations[sp_sid.species]
+        return db.num_matches(seqid=sp_sid.seqid, **kwargs)
+
+    def subset(self, **kwargs):
+        raise NotImplementedError
+
+    def add_feature(self, **kwargs):
+        raise NotImplementedError
+
+    def add_records(self, **kwargs):
+        raise NotImplementedError
+
+    def update(self, **kwargs):
+        raise NotImplementedError
+
+    def union(self, **kwargs):
+        raise NotImplementedError
+
+    def to_rich_dict(self) -> dict:
+        raise NotImplementedError
+
+    def to_json(self) -> str:
+        raise NotImplementedError
+
+    def from_dict(self, **kwargs) -> None:
+        raise NotImplementedError

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -597,28 +597,25 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         local_vars = {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype") and v is not None
+            if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype")
+            and v is not None
         }
         core_cols = "seqid", "start", "stop", "strand"
         repeat_cols = "repeat_type", "repeat_class", "repeat_name"
-        if kwargs := {
-            k: v
-            for k, v in local_vars.items()
-            if v is not None
-        }:
+        if kwargs := {k: v for k, v in local_vars.items() if v is not None}:
             like_conds = {k: v for k, v in kwargs.items() if k in repeat_cols}
             equals_conds = {k: v for k, v in kwargs.items() if k not in repeat_cols}
-            sql = _select_records_sql(
-                table_name="repeat_view",
-                equals_conds=equals_conds,
-                like_conds=like_conds,
-                columns=core_cols + repeat_cols,
-            )
-            sql += f" LIMIT {limit}" if limit else ""
         else:
-            sql = (
-                f"SELECT {','.join(core_cols + repeat_cols)} FROM repeat_view LIMIT 10"
-            )
+            like_conds = None
+            equals_conds = None
+
+        sql = _select_records_sql(
+            table_name="repeat_view",
+            equals_conds=equals_conds,
+            like_conds=like_conds,
+            columns=core_cols + repeat_cols,
+        )
+        sql += f" LIMIT {limit}" if limit else ""
 
         columns = core_cols + repeat_cols
         for record in self.conn.sql(sql).fetchall():

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -597,15 +597,12 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         local_vars = {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype") and v is not None
+            if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype")
+            and v is not None
         }
         core_cols = "seqid", "start", "stop", "strand"
         repeat_cols = "repeat_type", "repeat_class", "repeat_name"
-        if kwargs := {
-            k: v
-            for k, v in local_vars.items()
-            if v is not None
-        }:
+        if kwargs := {k: v for k, v in local_vars.items() if v is not None}:
             like_conds = {k: v for k, v in kwargs.items() if k in repeat_cols}
             equals_conds = {k: v for k, v in kwargs.items() if k not in repeat_cols}
             sql = _select_records_sql(

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -590,42 +590,42 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
     ) -> typing.Iterator[FeatureDataType]:
         limit = kwargs.pop("limit", None)
         local_vars = locals()
+        repeat_type = repeat_type or biotype
+        biotype = "repeat"
+        repeat_class = repeat_class or name
+        name = repeat_class
+        core_columns = "seqid", "start", "stop", "strand"
+        repeat_cols = "repeat_type", "repeat_class", "repeat_name"
         if kwargs := {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "limit", "local_vars") and v is not None
+            if k not in ("self", "kwargs", "limit", "local_vars", "biotype")
+            and v is not None
         }:
-            like_cols = "repeat_type", "repeat_class", "repeat_name"
-            like_conds = {k: v for k, v in kwargs.items() if k in like_cols}
-            equals_conds = {k: v for k, v in kwargs.items() if k not in like_cols}
-            columns = "seqid", "start", "stop", "strand"
+            like_conds = {k: v for k, v in kwargs.items() if k in repeat_cols}
+            equals_conds = {k: v for k, v in kwargs.items() if k not in repeat_cols}
             sql = _select_records_sql(
                 table_name="repeat_view",
                 equals_conds=equals_conds,
                 like_conds=like_conds,
-                columns=columns + like_cols,
+                columns=core_columns + repeat_cols,
             )
             sql += f" LIMIT {limit}" if limit else ""
         else:
-            columns = (
-                "seqid",
-                "start",
-                "stop",
-                "strand",
-                "repeat_type",
-                "repeat_class",
-                "repeat_name",
-            )
             sql = "SELECT * FROM repeat_view LIMIT 10"
 
+        columns = core_columns + repeat_cols
         for record in self.conn.sql(sql).fetchall():
-            data = dict(zip(columns, record, strict=False))
+            data = dict(zip(columns, record, strict=True))
+            rep_data = {k: data.pop(k) for k in repeat_cols}
             spans = numpy.array(
                 [(data.pop("start"), data.pop("stop"))],
                 dtype=numpy.int32,
             )
             data["spans"] = spans
             data["biotype"] = "repeat"
+            data["name"] = rep_data["repeat_name"]
+            data["xattr"] = rep_data
             yield FeatureDataType(**data)
 
     def get_children_matching(self, **kwargs):
@@ -689,7 +689,11 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
         biotype: str,
         **kwargs,
     ) -> typing.Iterator[FeatureDataType]:
-        view = self.repeats if biotype == "repeat" else self.genes
+        biotype = biotype or "protein_coding"
+        gene_biotypes = set(self.biotypes.distinct)
+        view = self.genes if biotype in gene_biotypes else self.repeats
+        if not view:
+            return
         if biotype != "repeat":
             kwargs["biotype"] = biotype
         yield from view.get_features_matching(**kwargs)

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -589,18 +589,22 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         **kwargs,  # noqa: ANN003
     ) -> typing.Iterator[FeatureDataType]:
         limit = kwargs.pop("limit", None)
-        local_vars = locals()
         repeat_type = repeat_type or biotype
         biotype = "repeat"
         repeat_class = repeat_class or name
         name = repeat_class
-        core_columns = "seqid", "start", "stop", "strand"
+        local_vars = locals()
+        local_vars = {
+            k: v
+            for k, v in local_vars.items()
+            if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype") and v is not None
+        }
+        core_cols = "seqid", "start", "stop", "strand"
         repeat_cols = "repeat_type", "repeat_class", "repeat_name"
         if kwargs := {
             k: v
             for k, v in local_vars.items()
-            if k not in ("self", "kwargs", "limit", "local_vars", "biotype")
-            and v is not None
+            if v is not None
         }:
             like_conds = {k: v for k, v in kwargs.items() if k in repeat_cols}
             equals_conds = {k: v for k, v in kwargs.items() if k not in repeat_cols}
@@ -608,13 +612,15 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
                 table_name="repeat_view",
                 equals_conds=equals_conds,
                 like_conds=like_conds,
-                columns=core_columns + repeat_cols,
+                columns=core_cols + repeat_cols,
             )
             sql += f" LIMIT {limit}" if limit else ""
         else:
-            sql = "SELECT * FROM repeat_view LIMIT 10"
+            sql = (
+                f"SELECT {','.join(core_cols + repeat_cols)} FROM repeat_view LIMIT 10"
+            )
 
-        columns = core_columns + repeat_cols
+        columns = core_cols + repeat_cols
         for record in self.conn.sql(sql).fetchall():
             data = dict(zip(columns, record, strict=True))
             rep_data = {k: data.pop(k) for k in repeat_cols}
@@ -625,8 +631,10 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
             data["spans"] = spans
             data["biotype"] = "repeat"
             data["name"] = rep_data["repeat_name"]
-            data["xattr"] = rep_data
-            yield FeatureDataType(**data)
+            data["start"] = spans.min()
+            data["stop"] = spans.max()
+            # data["xattr"] = rep_data
+            yield FeatureDataBase(**data)
 
     def get_children_matching(self, **kwargs):
         return ()
@@ -691,11 +699,14 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
     ) -> typing.Iterator[FeatureDataType]:
         biotype = biotype or "protein_coding"
         gene_biotypes = set(self.biotypes.distinct)
-        view = self.genes if biotype in gene_biotypes else self.repeats
+        kwargs["biotype"] = biotype
+        if biotype in gene_biotypes:
+            view = self.genes
+        else:
+            view = self.repeats
         if not view:
             return
-        if biotype != "repeat":
-            kwargs["biotype"] = biotype
+
         yield from view.get_features_matching(**kwargs)
 
     def __len__(self) -> int:

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -82,6 +82,8 @@ def _species_names_from_csv(
     return db_names
 
 
+_csv_or_file_help = "(comma separated or a path to file of names, one per line)"
+
 _click_command_opts = {
     "no_args_is_help": True,
     "context_settings": {"show_default": True},
@@ -113,7 +115,7 @@ _outdir = click.option(
     "--outdir",
     required=True,
     type=pathlib.Path,
-    help="path to write files",
+    help="Path to write files",
 )
 _align_name = click.option(
     "--align_name",
@@ -179,16 +181,21 @@ _species = click.option(
     callback=_species_names_from_csv,
     help="Single species name or multiple (comma separated).",
 )
-_mask_features = click.option(
-    "--mask_features",
+_mask = click.option(
+    "--mask",
     callback=_values_from_csv_or_file,
-    help="Biotypes to mask (comma separated).",
+    help=f"mask the specified biotypes {_csv_or_file_help}.",
+)
+_mask_shadow = click.option(
+    "--mask_shadow",
+    callback=_values_from_csv_or_file,
+    help=f"mask everything but the specified biotypes {_csv_or_file_help}.",
 )
 _coord_names = click.option(
     "--coord_names",
     default=None,
     callback=_values_from_csv_or_file,
-    help="Comma separated list of ref species chrom/coord names or a path leading to names, one per line.",
+    help=f"list of ref species chrom/coord names {_csv_or_file_help}.",
 )
 
 
@@ -434,7 +441,8 @@ def compara_summary(installed: pathlib.Path) -> None:
 @_ref
 @_coord_names
 @_ref_genes_file
-@_mask_features
+@_mask
+@_mask_shadow
 @_limit
 @_force
 @_verbose
@@ -445,7 +453,8 @@ def alignments(
     ref: str,
     coord_names: str,
     ref_genes_file: pathlib.Path,
-    mask_features: pathlib.Path,
+    mask: pathlib.Path,
+    mask_shadow: pathlib.Path,
     limit: int,
     force_overwrite: bool,
     verbose: bool,
@@ -455,6 +464,13 @@ def alignments(
     from rich import progress
 
     from ensembl_tui import _align as eti_align
+
+    if mask and mask_shadow:
+        eti_util.print_colour(
+            text="ERROR: cannot specify both mask and mask_shadow",
+            colour="red",
+        )
+        sys.exit(1)
 
     # TODO support genomic coordinates, e.g. coord_name:start-stop, for
     #  a reference species
@@ -474,7 +490,7 @@ def alignments(
     align_path = config.path_to_alignment(align_name, eti_align.ALIGN_STORE_SUFFIX)
     if align_path is None:
         eti_util.print_colour(
-            text=f"{align_name!r} does not match any alignments under {str(config.aligns_path)!r}",
+            text=f"{align_name!r} does not match any alignments under '{config.aligns_path}'",
             colour="red",
         )
         available = "\n".join(
@@ -537,10 +553,13 @@ def alignments(
         stableids=stableids,
     )
 
+    mask = mask_shadow or mask
+    shadow = bool(mask_shadow)
     maker = eti_align.construct_alignment(
         align_db=align_db,
         genomes=genomes,
-        mask_features=mask_features,
+        mask_features=mask,
+        shadow=shadow,
     )
     output = open_data_store(outdir, mode="w", suffix="fa")
     writer = get_app("write_seqs", format="fasta", data_store=output)
@@ -561,6 +580,7 @@ def alignments(
         for alignments in maker.as_completed(locations, show_progress=False):
             progress.update(task, advance=1)
             if not alignments:
+                eti_util.print_colour(str(alignments), colour="red")
                 continue
             input_source = alignments[0].info.source
             if len(alignments) == 1:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -71,7 +71,8 @@ def get_annotation_db() -> dict[str, eti_annots.Annotations]:
         ),
     }
     for sp, gv in gene_attr.items():
-        gene_attr[sp] = eti_annots.Annotations(source=":memory:", genes=gv)
+        bt = eti_annots.BiotypeView(source=gv.source, db=gv.conn)
+        gene_attr[sp] = eti_annots.Annotations(source=":memory:", genes=gv, biotypes=bt)
     return gene_attr
 
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -380,7 +380,7 @@ def test_get_alignment_features(coord):
     got = next(
         iter(eti_align.get_alignment(align_db=align_db, genomes=genomes, **kwargs)),
     )
-    assert len(got.annotation_db) == 1
+    assert len(got.annotation_db) == 3
 
 
 @pytest.mark.parametrize(
@@ -401,7 +401,7 @@ def test_get_alignment_masked_features(coord):
     got = next(
         iter(eti_align.get_alignment(align_db=align_db, genomes=genomes, **kwargs)),
     )
-    assert len(got.annotation_db) == 1
+    assert len(got.annotation_db) == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -197,16 +197,20 @@ def multi_species_db(yeast_db, worm_db):
 def test_multi_species(multi_species_db):
     stable_id = "WBGene00011936"
     kwargs = {"name": stable_id, "biotype": "protein_coding"}
-    gene = next(iter(
-        multi_species_db.get_features_matching(seqid=f"worm-{stable_id}", **kwargs),
-    ))
-    expect = next(iter(
-        multi_species_db.species_annotations[
-            "caenorhabditis_elegans"
-        ].get_features_matching(**kwargs),
-    ))
-    got =  dict(gene)
-    got["spans"] =  got["spans"].tolist()
+    gene = next(
+        iter(
+            multi_species_db.get_features_matching(seqid=f"worm-{stable_id}", **kwargs),
+        ),
+    )
+    expect = next(
+        iter(
+            multi_species_db.species_annotations[
+                "caenorhabditis_elegans"
+            ].get_features_matching(**kwargs),
+        ),
+    )
+    got = dict(gene)
+    got["spans"] = got["spans"].tolist()
     expect = dict(expect)
-    expect["spans"] =  expect["spans"].tolist()
+    expect["spans"] = expect["spans"].tolist()
     assert got == expect

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,11 +1,11 @@
 import pytest
 
-import ensembl_tui._annotation as gen_pqt
+import ensembl_tui._annotation as eti_anno
 
 
 @pytest.fixture
 def gene_view(genome_dir):
-    return gen_pqt.GeneView(source=genome_dir)
+    return eti_anno.GeneView(source=genome_dir)
 
 
 def test_select_protein_coding(worm_genes):
@@ -87,13 +87,13 @@ def test_repeat_view_count_distinct(worm_repeats):
 
 
 def test_create_genome(genome_dir):
-    g = gen_pqt.Annotations(source=genome_dir)
+    g = eti_anno.Annotations(source=genome_dir)
     prot = list(g.get_features_matching(biotype="protein_coding"))
     assert prot
 
 
 def test_get_feature_by_symbol(genome_dir):
-    g = gen_pqt.GeneView(source=genome_dir)
+    g = eti_anno.GeneView(source=genome_dir)
     features = list(g.get_by_symbol(symbol="sms-2"))
     assert features
     # validate that all genes have a span with single start and stop
@@ -104,21 +104,21 @@ def test_get_feature_by_symbol(genome_dir):
 
 
 def test_get_feature_by_description(genome_dir):
-    g = gen_pqt.GeneView(source=genome_dir)
+    g = eti_anno.GeneView(source=genome_dir)
     features = list(g.get_by_description(description="Alcohol dehydrogenase"))
     assert features
     assert all("alcohol dehydrogenase" in ft["description"].lower() for ft in features)
 
 
 def test_canonical_cds(genome_dir):
-    g = gen_pqt.GeneView(source=genome_dir)
+    g = eti_anno.GeneView(source=genome_dir)
     gene = next(iter(g.get_features_matching(stable_id="WBGene00004893")))
     cds = g.get_cds(gene=gene)
     assert cds.stable_id == "F53H8.4.1"  # ID from ensembl.org
 
 
 def test_featuredb(genome_dir):
-    db = gen_pqt.GeneView(source=genome_dir)
+    db = eti_anno.GeneView(source=genome_dir)
     gene = next(iter(db.get_by_stable_id(stable_id="WBGene00000138")))
     cds = next(iter(db.get_feature_children(gene)))
     assert cds.stable_id.startswith("B0019.1")
@@ -147,14 +147,14 @@ def test_convert_to_dict():
         "gene_stable_id": "WBGene00011936",
         "transcript_id": 16967,
     }
-    cds = gen_pqt.CdsData(**raw)
+    cds = eti_anno.CdsData(**raw)
     got = dict(cds)
     assert isinstance(got, dict)
 
 
 def test_get_ids_for_biotype(small_install_cfg):
     config = small_install_cfg
-    genome = gen_pqt.GeneView(
+    genome = eti_anno.GeneView(
         source=config.installed_genome(species="caenorhabditis_elegans"),
     )
     stable_ids = genome.get_ids_for_biotype(biotype="protein_coding", limit=10)
@@ -176,3 +176,37 @@ def test_view_species(worm_db):
     assert worm_db.genes.species == "caenorhabditis_elegans"
     assert worm_db.repeats.species == "caenorhabditis_elegans"
     assert worm_db.biotypes.species == "caenorhabditis_elegans"
+
+
+@pytest.fixture
+def multi_species_db(yeast_db, worm_db):
+    dbs = {"caenorhabditis_elegans": worm_db, "saccharomyces_cerevisiae": yeast_db}
+    name_map = {
+        "worm-WBGene00011936": eti_anno.get_species_seqid(
+            species="caenorhabditis_elegans",
+            seqid="I",
+        ),
+        "yeast-YCR105W": eti_anno.get_species_seqid(
+            species="saccharomyces_cerevisiae",
+            seqid="III",
+        ),
+    }
+    return eti_anno.MultispeciesAnnotations(species_annotations=dbs, name_map=name_map)
+
+
+def test_multi_species(multi_species_db):
+    stable_id = "WBGene00011936"
+    kwargs = {"name": stable_id, "biotype": "protein_coding"}
+    gene = next(iter(
+        multi_species_db.get_features_matching(seqid=f"worm-{stable_id}", **kwargs),
+    ))
+    expect = next(iter(
+        multi_species_db.species_annotations[
+            "caenorhabditis_elegans"
+        ].get_features_matching(**kwargs),
+    ))
+    got =  dict(gene)
+    got["spans"] =  got["spans"].tolist()
+    expect = dict(expect)
+    expect["spans"] =  expect["spans"].tolist()
+    assert got == expect

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -208,6 +208,17 @@ def test_get_celegans_cds(worm):
 
 
 def test_yeast_repeat(yeast):
-    repeat = next(iter(yeast.get_features(biotype="dust", name="dust", seqid="VI", limit=20, start=8680, stop=9000)))
+    repeat = next(
+        iter(
+            yeast.get_features(
+                biotype="dust",
+                name="dust",
+                seqid="VI",
+                limit=20,
+                start=8680,
+                stop=9000,
+            ),
+        ),
+    )
     seq = repeat.get_slice()
     assert str(seq) == "AAAAAAAAAA"

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -205,3 +205,9 @@ def test_get_celegans_cds(worm):
     seq = cds.get_slice()
     aa = seq.get_translation()
     assert aa == "MIIPIRCFTCGKVIGDKWETYLGFLQSEYSEGDALDALGLRRYCCRRMLLAHVDLIEKLLNYHPLEK"
+
+
+def test_yeast_repeat(yeast):
+    repeat = next(iter(yeast.get_features(biotype="dust", name="dust", seqid="VI", limit=20, start=8680, stop=9000)))
+    seq = repeat.get_slice()
+    assert str(seq) == "AAAAAAAAAA"

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -208,6 +208,12 @@ def test_get_celegans_cds(worm):
 
 
 def test_yeast_repeat(yeast):
-    repeat = next(iter(yeast.get_features(biotype="dust", name="dust", seqid="VI", limit=20, start=8680, stop=9000)))
+    repeat = next(
+        iter(
+            yeast.get_features(
+                biotype="dust", name="dust", seqid="VI", limit=20, start=8680, stop=9000
+            )
+        )
+    )
     seq = repeat.get_slice()
     assert str(seq) == "AAAAAAAAAA"


### PR DESCRIPTION
## Summary by Sourcery

This pull request enables support for queries involving repeats and introduces multi-species alignment capabilities. It also adds masking functionality to alignments based on biotypes.

Enhancements:
- Adds support for repeat queries, allowing users to search for specific repeat types, classes, or names.
- Implements multi-species alignment by creating a composite annotation database.
- Adds masking functionality to alignments, allowing users to mask specific biotypes or everything except specified biotypes.
- Improves handling of biotype specifications in feature queries.
- Adds a utility function to retrieve species and sequence ID combinations.
- Adds caching to the species_seqid dataclass

Tests:
- Adds tests for multi-species alignment functionality.
- Adds tests for yeast repeats.