### PR TITLE
MAINT: stop annoying warnings from loky

### DIFF
--- a/src/ensembl_tui/__init__.py
+++ b/src/ensembl_tui/__init__.py
@@ -4,6 +4,7 @@ from warnings import filterwarnings
 
 filterwarnings("ignore", message=".*MPI")
 filterwarnings("ignore", message="Can't drop database.*")
+filterwarnings("ignore", message="A worker stopped while some jobs.*")
 
 
 __version__ = "0.1a9"


### PR DESCRIPTION
[CHANGED] these are more likely coming from cogent3 than this project

## Summary by Sourcery

Chores:
- Ignore warning messages related to worker stoppage during job execution.