### PR TITLE
BUG: fix unexpected compara folder creation when installing with a compara-lacking config

### DIFF
--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -92,7 +92,7 @@ def local_install_alignments(
     verbose: bool = False,
     progress: Progress | None = None,
 ) -> None:
-    # Check if alignments are specified in the config
+    # check if alignments are specified in the config
     if not config.align_names:
         if verbose:
             eti_util.print_colour(
@@ -123,7 +123,7 @@ def local_install_homology(
     verbose: bool = False,
     progress: Progress | None = None,
 ) -> None:
-    # Check if homologies are specified in the config
+    # check if homologies are specified in the config
     if not config.homologies:
         if verbose:
             eti_util.print_colour(

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -92,6 +92,15 @@ def local_install_alignments(
     verbose: bool = False,
     progress: Progress | None = None,
 ) -> None:
+    # Check if alignments are specified in the config
+    if not config.align_names:
+        if verbose:
+            eti_util.print_colour(
+                "No alignments specified in the config. Skipping alignment installation.",
+                "yellow",
+            )
+        return
+
     if force_overwrite:
         shutil.rmtree(config.install_aligns, ignore_errors=True)
 
@@ -114,6 +123,15 @@ def local_install_homology(
     verbose: bool = False,
     progress: Progress | None = None,
 ) -> None:
+    # Check if homologies are specified in the config
+    if not config.homologies:
+        if verbose:
+            eti_util.print_colour(
+                "No homologies specified in the config. Skipping homology installation.",
+                "yellow",
+            )
+        return
+
     if force_overwrite:
         shutil.rmtree(config.install_homologies, ignore_errors=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,3 +160,25 @@ def worm_repeats(worm_db):
 @pytest.fixture
 def genome_dir(small_install_cfg):
     return small_install_cfg.installed_genome(species="caenorhabditis_elegans")
+
+
+@pytest.fixture(scope="module")
+def tmp_config_no_compara(tmp_path_factory, small_download_path):
+    # modify the small_download_path to remove the compara folder
+    tmp_path = tmp_path_factory.mktemp("downloaded")
+    dest = tmp_path / small_download_path.name
+    shutil.copytree(small_download_path, dest)
+    shutil.rmtree(dest / "genomes" / "saccharomyces_cerevisiae")
+    shutil.rmtree(dest / "compara")
+
+    # create a config with one specie but without compara section
+    parser = ConfigParser()
+    parser.read(next(iter(small_download_path.glob("*cfg"))))
+    parser.remove_section("saccharomyces_cerevisiae")
+    parser.remove_section("compara")
+
+    download_cfg = dest / "downloaded.cfg"
+    with open(download_cfg, "w") as out:
+        parser.write(out)
+
+    return dest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,7 +250,7 @@ def test_compara_summary(installed):
 
 @pytest.mark.slow
 def test_compara_folder_not_created(tmp_config_no_compara):
-    # ensure 'compara' folder is not created if not specified in the config
+    # ensure compara folder is not created if not specified in the config
     r = RUNNER.invoke(
         eti_cli.install,
         [f"-d{tmp_config_no_compara}"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,3 +246,15 @@ def test_compara_summary(installed):
     assert r.exit_code == 0, r.output
     assert "homology_type" in r.output
     assert "ortholog_one2many" in r.output
+
+
+@pytest.mark.slow
+def test_compara_folder_not_created(tmp_config_no_compara):
+    # ensure 'compara' folder is not created if not specified in the config
+    r = RUNNER.invoke(
+        eti_cli.install,
+        [f"-d{tmp_config_no_compara}"],
+        catch_exceptions=False,
+    )
+    assert r.exit_code == 0, r.output
+    assert not (tmp_config_no_compara / "compara").exists()


### PR DESCRIPTION
In this PR:
- add conditions in the homology and alignment installing functions to check if compara section is present in the config. 
- a new fixture to create config with no compara section and downloaded parent folder excluding compara folder.
- a test function utilises the above fixture and verifies compara folder absent.


fix #201

## Summary by Sourcery

Prevent unexpected compara folder creation when installing with a configuration lacking compara section

Bug Fixes:
- Add checks to prevent creating compara folders when no compara-related configurations are specified

Enhancements:
- Improve installation functions to gracefully handle configurations without compara or alignment specifications

Tests:
- Add a new test fixture to verify that compara folder is not created when not specified in the configuration
- Implement a test to ensure no compara folder is created for a configuration without compara section