### PR TITLE
MAINT: change to simplified cogent3 AnnotationDbABC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = ["blosc2",
         "click",
-        "cogent3>=2025.3.22a4",
+        # following needs to be replaced by cogent3>=version when
+        # cogent3 annotation db API changes are released
+        "cogent3 @ git+https://github.com/cogent3/cogent3.git@develop",
         "duckdb",
         "h5py",
         "hdf5plugin",

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -714,12 +714,6 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
     def __len__(self) -> int:
         return self.num_records()
 
-    def add_records(self, **kwargs):
-        raise NotImplementedError
-
-    def add_feature(self, **kwargs):
-        raise NotImplementedError
-
     def get_feature_children(self, **kwargs):
         raise NotImplementedError
 
@@ -727,36 +721,6 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
         raise NotImplementedError
 
     def num_matches(self, **kwargs):
-        raise NotImplementedError
-
-    def subset(self, **kwargs):
-        # this should return a cogent3 BasicAnnotationDb
-        # or we need a AnnotationsUnion class that
-        # encloses the individual Annotations instances
-        # to avoid copying
-        raise NotImplementedError
-
-    def union(self, **kwargs):
-        # this should return a cogent3 BasicAnnotationDb
-        # or we need a AnnotationsUnion class that
-        # encloses the individual Annotations instances
-        # to avoid copying
-        raise NotImplementedError
-
-    def update(self, **kwargs):
-        # this should return a cogent3 BasicAnnotationDb
-        # or we need a AnnotationsUnion class that
-        # encloses the individual Annotations instances
-        # to avoid copying
-        raise NotImplementedError
-
-    def to_json(self) -> str:
-        raise NotImplementedError
-
-    def to_rich_dict(self) -> dict:
-        raise NotImplementedError
-
-    def from_dict(self, data: dict[str, typing.Any]) -> None:
         raise NotImplementedError
 
     def get_cds(self, **kwargs) -> CdsData:  # noqa: ANN003
@@ -827,27 +791,3 @@ class MultispeciesAnnotations(AnnotationDbABC):
         sp_sid = self.name_map[seqid]
         db = self.species_annotations[sp_sid.species]
         return db.num_matches(seqid=sp_sid.seqid, **kwargs)
-
-    def subset(self, **kwargs):
-        raise NotImplementedError
-
-    def add_feature(self, **kwargs):
-        raise NotImplementedError
-
-    def add_records(self, **kwargs):
-        raise NotImplementedError
-
-    def update(self, **kwargs):
-        raise NotImplementedError
-
-    def union(self, **kwargs):
-        raise NotImplementedError
-
-    def to_rich_dict(self) -> dict:
-        raise NotImplementedError
-
-    def to_json(self) -> str:
-        raise NotImplementedError
-
-    def from_dict(self, **kwargs) -> None:
-        raise NotImplementedError


### PR DESCRIPTION
[CHANGED] the cogent3 base class now makes some methods optional
    and provides them as concrete methods on the base class
    which default to raising NotImplementedError. We delete these
    from our implementation.

## Summary by Sourcery

Simplify the AnnotationDbABC implementation by removing redundant method implementations that now default to raising NotImplementedError in the cogent3 base class

Enhancements:
- Removed multiple method implementations that are now handled by the base class in cogent3

Chores:
- Updated project dependency to use the develop branch of cogent3 to support the new annotation database API