### PR TITLE
ENH: add extra meta-data to demp-genes output, fixes #223

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-data-v2-${{ hashFiles('tests/data/small-113.zip') }}
+          key: ${{ runner.os }}-data-v3-${{ hashFiles('tests/data/small-113.zip') }}
           restore-keys: |
-            ${{ runner.os }}-data-v2-
+            ${{ runner.os }}-data-v3-
 
       - name: Check cache status
         run: |

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -653,7 +653,46 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
             for record in self.get_features_matching()
         )
         header = ["stableid" if c == "name" else c for c in columns]
-        return cogent3.make_table(header=header, data=rows)
+        table = cogent3.make_table(header=header, data=rows)
+        # get the numbers of transcripts per gene
+        sql = """SELECT ga.stable_id, COUNT(DISTINCT ta.transcript_id) AS distinct_transcript_count
+                 FROM transcript_attr ta
+                 JOIN gene_attr ga ON ta.gene_id = ga.gene_id
+                 GROUP BY ga.stable_id
+                 """
+        transcript_counts = dict(self.conn.sql(sql).fetchall())
+        table = table.with_new_column(
+            "num_transcripts",
+            lambda x: transcript_counts.get(x, 0),
+            columns="stableid",
+        )
+        # get the transcript biotypes
+        sql = """SELECT ga.stable_id, STRING_AGG(DISTINCT ta.transcript_biotype, ',') AS transcript_biotypes
+                 FROM transcript_attr ta
+                 JOIN gene_attr ga ON ta.gene_id = ga.gene_id
+                 GROUP BY ga.stable_id
+                 """
+        transcript_biotypes = dict(self.conn.sql(sql).fetchall())
+        table = table.with_new_column(
+            "transcript_biotypes",
+            lambda x: transcript_biotypes.get(x, ""),
+            columns="stableid",
+        )
+        columns = (
+            "species",
+            "seqid",
+            "seqid",
+            "source",
+            "biotype",
+            "transcript_biotypes",
+            "num_transcripts",
+            "start",
+            "stop",
+            "strand",
+            "symbol",
+            "description",
+        )
+        return table.get_columns(columns=columns)
 
 
 @dataclasses.dataclass

--- a/src/ensembl_tui/_mysql_core_attr.py
+++ b/src/ensembl_tui/_mysql_core_attr.py
@@ -20,6 +20,7 @@ TRANSCRIPT_ATTR_SCHEMA = (
     "transcript_spans BLOB",
     "cds_spans BLOB",
     "transcript_stable_id TEXT",
+    "transcript_biotype TEXT",
     "cds_stable_id TEXT",
 )
 TRANSCRIPT_ATTR_COLS = eti_util.make_column_constant(TRANSCRIPT_ATTR_SCHEMA)
@@ -220,6 +221,7 @@ class TranscriptAttrRecord:
     transcript_spans: numpy.ndarray
     cds_spans: numpy.ndarray | None
     transcript_stable_id: str
+    transcript_biotype: str
     cds_stable_id: str
 
     @property
@@ -246,6 +248,7 @@ class TranscriptAttrRecord:
             "transcript_spans": eti_storage.array_to_blob(self.transcript_spans),
             "cds_spans": cds_blob,
             "transcript_stable_id": self.transcript_stable_id,
+            "transcript_biotype": self.transcript_biotype,
             "cds_stable_id": self.cds_stable_id,
         }
         return tuple(mapping[c] for c in columns)
@@ -265,14 +268,17 @@ def get_transcript_attr_records(
     # we use SQL aggregate functions followed by numpy.fromstring to
     # greatly speedup extraction of all exon coords
     sql = """SELECT
-    transcript_id, gene_id, strand, seqid, transcript_stable_id, cds_stable_id,
+    transcript_id, gene_id, strand, seqid,
+    transcript_stable_id, cds_stable_id,
+    transcript_biotype,
     STRING_AGG(CAST(start AS VARCHAR), ' ') AS agg_start,
     STRING_AGG(CAST(stop AS VARCHAR), ' ') AS agg_stop,
     STRING_AGG(CAST(rank AS VARCHAR), ' ') AS agg_rank,
     STRING_AGG(CAST(phase AS VARCHAR), ' ') AS agg_phase,
     STRING_AGG(CAST(end_phase AS VARCHAR), ' ') AS agg_end_phase
     FROM exon_view
-    GROUP BY transcript_id, gene_id, strand, seqid, transcript_stable_id, cds_stable_id
+    GROUP BY transcript_id, gene_id, strand, seqid,
+    transcript_stable_id, cds_stable_id, transcript_biotype
     """
     limit_exons = get_all_limit_exons(conn)
     for (
@@ -282,6 +288,7 @@ def get_transcript_attr_records(
         seqid,
         transcript_stable_id,
         cds_stable_id,
+        transcript_biotype,
         agg_start,
         agg_stop,
         agg_rank,
@@ -316,6 +323,7 @@ def get_transcript_attr_records(
                 cds_spans=None,
                 transcript_stable_id=transcript_stable_id,
                 cds_stable_id=cds_stable_id,
+                transcript_biotype=transcript_biotype,
             )
             continue
 
@@ -341,6 +349,7 @@ def get_transcript_attr_records(
                 cds_spans=cds_spans,
                 transcript_stable_id=transcript_stable_id,
                 cds_stable_id=cds_stable_id,
+                transcript_biotype=transcript_biotype,
             )
             continue
 
@@ -383,6 +392,7 @@ def get_transcript_attr_records(
             cds_spans=cds_spans,
             transcript_stable_id=transcript_stable_id,
             cds_stable_id=cds_stable_id,
+            transcript_biotype=transcript_biotype,
         )
 
     return
@@ -403,6 +413,7 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
             et.rank AS rank,
             tr.gene_id as gene_id,
             tr.stable_id as transcript_stable_id,
+            tr.biotype as transcript_biotype,
             tl.stable_id as cds_stable_id,
         FROM exon ex
         JOIN seq_region sr ON ex.seq_region_id = sr.seq_region_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,7 @@ def test_species_summary(installed):
 def test_dump_genes(installed):
     species = "caenorhabditis_elegans"
     outdir = installed.parent
+    limit = 10
     args = [
         f"-i{installed}",
         "--species",
@@ -170,7 +171,7 @@ def test_dump_genes(installed):
         "--outdir",
         str(outdir),
         "--limit",
-        "10",
+        f"{limit}",
     ]
     r = RUNNER.invoke(
         eti_cli.dump_genes,
@@ -181,7 +182,10 @@ def test_dump_genes(installed):
     tsv_path = next(iter(outdir.glob("*.tsv")))
     assert tsv_path.name.startswith(species)
     table = cogent3.load_table(tsv_path)
-    assert table.shape[0] == 10
+    assert table.shape[0] == limit
+    gene_biotype = str(table.columns["biotype"][0])
+    transcript_biotype = set(table.columns["transcript_biotypes"][0].split(","))
+    assert gene_biotype in transcript_biotype
 
 
 @pytest.mark.slow

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -33,6 +33,7 @@ EXON_VIEW_SCHEMA = (
     "cds_stable_id TEXT",
     "phase TINYINT",
     "end_phase TINYINT",
+    "transcript_biotype TEXT",
 )
 
 EXON_VIEW_COLS = [c.split()[0] for c in EXON_VIEW_SCHEMA]
@@ -69,6 +70,7 @@ TRANSCRIPT_SCHEMA = (
     "transcript_id INTEGER",
     "gene_id INTEGER",
     "stable_id TEXT",
+    "biotype TEXT",
 )
 
 TRANSCRIPT_COLS = [c.split()[0] for c in TRANSCRIPT_SCHEMA]
@@ -341,7 +343,7 @@ def four_exons(empty_ev_tr):
     value_placeholder = "?, " * len(EXON_VIEW_COLS)
     conn.executemany(
         f"INSERT INTO exon_view VALUES ({value_placeholder})",
-        parameters=[[r[c] for c in EXON_VIEW_COLS] for r in exon_view_data],
+        parameters=[[r.get(c) for c in EXON_VIEW_COLS] for r in exon_view_data],
     )
     return conn
 
@@ -471,7 +473,7 @@ def two_exons_minus_strand(empty_ev_tr):
 
     conn.executemany(
         f"INSERT INTO exon_view VALUES ({value_placeholder})",
-        [[r[c] for c in EXON_VIEW_COLS] for r in exon_view_data],
+        [[r.get(c) for c in EXON_VIEW_COLS] for r in exon_view_data],
     )
     return conn
 
@@ -511,8 +513,8 @@ def test_no_cds_spans(four_exons):
     tr = next(iter(eti_tables.get_transcript_attr_records(four_exons)))
     assert tr.cds_spans is None
     record = tr.to_record(eti_tables.TRANSCRIPT_ATTR_COLS)
-    assert record[-3] is None
-    assert len(record) == 10
+    assert record[-4] is None
+    assert len(record) == 11
 
 
 def single_tables_db():
@@ -635,8 +637,8 @@ def mixed_data():
         {"transcript_id": 12, "gene_id": 43, "stable_id": "tr-02"},
     ]
     conn.executemany(
-        "INSERT INTO transcript VALUES (?, ?, ?)",
-        parameters=[[r[c] for c in TRANSCRIPT_COLS] for r in tr_data],
+        "INSERT INTO transcript VALUES (?, ?, ?, ?)",
+        parameters=[[r.get(c) for c in TRANSCRIPT_COLS] for r in tr_data],
     )
 
     tl_data = [


### PR DESCRIPTION
[CHANGED] add transcript_attr.transcript_biotype column as this
    can differ from the gene_attr.biotype. Supporting this
    required changes to multiple places in the code.

[CHANGED] updated the cached small-113 test data set and updated
    the github action to a new tag to force re-download.

[NEW] add num_transcripts coilumn to the dump-genes output.
    This is required to support the data sampling scheme outlined
    in the Eory et al paper, where they distinguish
    protein coding genes with single transcripts from those with
    alternate splicing (multiple transcripts).

[NEW] add transcript_biotypes column as comma separated values
    to the dump-genes output. This is will be useful for filtering
    genes for other eti commands.

## Summary by Sourcery

Enhance gene dump functionality by adding transcript-related metadata to the output, including transcript biotypes and transcript count

New Features:
- Add num_transcripts column to gene dump output to support data sampling schemes
- Add transcript_biotypes column as comma-separated values for gene filtering

Enhancements:
- Modify gene table generation to include additional transcript-related metadata
- Update database schema to support transcript biotype tracking

CI:
- Update GitHub Actions cache key to force re-download of test data

Tests:
- Update test cases to accommodate new transcript metadata columns