### PR TITLE
Enhancement

### DIFF
--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -73,7 +73,11 @@ def species_names_from_csv(
     return db_names
 
 
-def genome_coords_from_tsv(tsv_file: pathlib.Path) -> list[eti_genome.genome_segment]:
+def genome_coords_from_tsv(
+    ctx: "Context",  # noqa: ARG001
+    param: "Option",  # noqa: ARG001
+    tsv_file: pathlib.Path,
+) -> list[eti_genome.genome_segment]:
     """reads a tsv file containing genomic coordinates and converts each
     line into a genome segment instance
 
@@ -126,7 +130,7 @@ def genome_coords_from_tsv(tsv_file: pathlib.Path) -> list[eti_genome.genome_seg
 
     return [
         eti_genome.genome_segment(
-            species=str(sp),
+            species=str(eti_species.Species.get_ensembl_db_prefix(sp)),
             seqid=str(seqid),
             start=int(start),
             stop=int(stop),
@@ -197,7 +201,7 @@ ref = click.option("--ref", default=None, help="Reference species.")
 ref_genes_file = click.option(
     "--ref_genes_file",
     default=None,
-    type=click.Path(resolve_path=True, exists=True),
+    type=pathlib.Path,
     help=".csv or .tsv file with a header containing a stableid column.",
 )
 mask_ref = click.option(

--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -204,6 +204,13 @@ ref_genes_file = click.option(
     type=pathlib.Path,
     help=".csv or .tsv file with a header containing a stableid column.",
 )
+ref_coords = click.option(
+    "--ref_coords",
+    type=pathlib.Path,
+    default=None,
+    callback=genome_coords_from_tsv,
+    help="Path to tsv file with genomic coordinates in ref species.",
+)
 mask_ref = click.option(
     "--mask_ref",
     is_flag=True,

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -10,12 +10,12 @@ from cogent3 import get_app, load_table, open_data_store
 from scitrack import CachingLogger
 
 from ensembl_tui import __version__
+from ensembl_tui import _cli_option as cli_opt
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _homology as eti_homology
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
-from src.ensembl_tui import _cli_option as cli_opt
 
 _click_command_opts = {
     "no_args_is_help": True,
@@ -456,6 +456,7 @@ def homologs(
 @cli_opt.mask
 @cli_opt.mask_shadow
 @cli_opt.mask_ref
+@cli_opt.ref_coords
 @cli_opt.limit
 @cli_opt.force
 @cli_opt.verbose
@@ -469,6 +470,7 @@ def alignments(
     mask: pathlib.Path,
     mask_shadow: pathlib.Path,
     mask_ref: bool,
+    ref_coords: list[eti_genome.genome_segment],
     limit: int,
     force_overwrite: bool,
     verbose: bool,
@@ -537,6 +539,13 @@ def alignments(
         for sp in align_db.get_species_names()
     }
 
+    if ref_genes_file and ref_coords:
+        eti_util.print_colour(
+            text="ERROR: cannot specify both ref_genes_file and ref_coords",
+            colour="red",
+        )
+        sys.exit(1)
+
     # load the gene stable ID's
     if ref_genes_file:
         table = load_table(ref_genes_file)
@@ -559,12 +568,15 @@ def alignments(
     else:
         stableids = None
 
-    locations = eti_genome.get_gene_segments(
-        annot_db=genomes[ref_species].annotation_db,
-        species=ref_species,
-        limit=limit,
-        stableids=stableids,
-    )
+    if ref_coords:
+        locations = ref_coords
+    else:
+        locations = eti_genome.get_gene_segments(
+            annot_db=genomes[ref_species].annotation_db,
+            species=ref_species,
+            limit=limit,
+            stableids=stableids,
+        )
 
     mask = mask_shadow or mask
     shadow = bool(mask_shadow)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,7 +273,7 @@ def test_genome_coords_from_tsv(tmp_dir):
     species_tsv = tmp_dir / "genome_coords.tsv"
     with open(species_tsv, "w") as f:
         f.write("species\tseqid\tstart\tstop\tstrand\nhomo_sapiens\t1\t3000\t4000\t1\n")
-    coords = cli_opt.genome_coords_from_tsv(species_tsv)
+    coords = cli_opt.genome_coords_from_tsv(None, None, species_tsv)
     assert len(coords) == 1
     got = coords[0]
     assert got.species == "homo_sapiens"
@@ -288,7 +288,7 @@ def test_genome_coords_from_tsv_noheader(tmp_dir, capsys):
     with open(invalid, "w") as f:
         f.write("homo_sapiens\t1\t3000\t4000\t1\n")
     with pytest.raises(SystemExit) as excinfo:
-        cli_opt.genome_coords_from_tsv(invalid)
+        cli_opt.genome_coords_from_tsv(None, None, invalid)
 
     captured = capsys.readouterr()
     assert "ERROR: failed to load file" in captured.out
@@ -300,7 +300,7 @@ def test_genome_coords_from_tsv_missing_value(tmp_dir, capsys):
     with open(invalid, "w") as f:
         f.write("species\tseqid\tstart\tstop\tstrand\nhomo_sapiens\t1\t3000\t\t1\n")
     with pytest.raises(SystemExit) as excinfo:
-        cli_opt.genome_coords_from_tsv(invalid)
+        cli_opt.genome_coords_from_tsv(None, None, invalid)
 
     captured = capsys.readouterr()
     assert "ERROR: all values of 'stop' must be integers" in captured.out


### PR DESCRIPTION
## Summary by Sourcery

Add support for specifying reference genomic coordinates directly via a CLI option

New Features:
- Introduce a new CLI option '--ref_coords' to allow users to specify genomic coordinates directly from a TSV file

Enhancements:
- Modify the genome coordinates parsing function to use Ensembl species database prefix
- Update the CLI option for reference genes file to use pathlib.Path

Tests:
- Update existing tests to accommodate changes in the genome coordinates parsing function