### PR TITLE
DEV: handle NoneType in genome_coords_from_tsv, fixes #233

### DIFF
--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -93,7 +93,7 @@ def species_names_from_csv(
 def genome_coords_from_tsv(
     ctx: "Context",  # noqa: ARG001
     param: "Option",  # noqa: ARG001
-    tsv_file: pathlib.Path,
+    tsv_file: pathlib.Path | None,
 ) -> list[eti_genome.genome_segment]:
     """reads a tsv file containing genomic coordinates and converts each
     line into a genome segment instance
@@ -103,6 +103,8 @@ def genome_coords_from_tsv(
     A tsv file with the following column headings
     species seqid start stop strand
     """
+    if not tsv_file:
+        return None
 
     if not tsv_file.exists():
         eti_util.print_colour(


### PR DESCRIPTION
fixes #233

## Summary by Sourcery

Handle NoneType input in genome_coords_from_tsv function to improve robustness

Bug Fixes:
- Fixed an issue where the genome_coords_from_tsv function did not handle None input, potentially causing errors

Enhancements:
- Modified function signature to explicitly allow None as a valid input type for tsv_file
- Added a check to return None when tsv_file is None