### PR TITLE
BUG: fix error in getting gene stableid's from tsv file

### DIFF
--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -25,7 +25,7 @@ def stableids_from_tsv(
             colour="red",
         )
         sys.exit(1)
-    return table.columns["stableid"].to_list()
+    return table.columns["stableid"].tolist()
 
 
 def values_from_csv_or_file(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace to_list() with .tolist() when retrieving the stableid column to ensure correct list conversion