### PR TITLE
Mods for Ensembl 114 and to grab more core mysql tables

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-data-v3-${{ hashFiles('tests/data/small-113.zip') }}
+          key: ${{ runner.os }}-data-v4-${{ hashFiles('tests/data/small-114.zip') }}
           restore-keys: |
-            ${{ runner.os }}-data-v3-
+            ${{ runner.os }}-data-v4-
 
       - name: Check cache status
         run: |
@@ -39,12 +39,12 @@ jobs:
       - name: Download data file
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: |
-          curl -L -o tests/data/small-113.zip "https://www.dropbox.com/scl/fi/pfmwzz96gusdeqi0a9wax/small-113.zip?rlkey=r60l1eq9jk6p440tkqslmqihi&st=ud49fits&dl=1"
+          curl -L -o tests/data/small-114.zip "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
 
       - name: Unzip data file
         run: |
           cd tests/data
-          unzip -o -q small-113.zip
+          unzip -o -q small-114.zip
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.3"]
 
     steps:
       - uses: "actions/checkout@v4"
@@ -46,6 +46,10 @@ jobs:
           cd tests/data
           unzip -o -q small-114.zip
 
+      - uses: "actions/setup-python@v5"
+        with:
+            python-version: "${{ matrix.python-version }}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
@@ -59,7 +63,7 @@ jobs:
 
       - name: "Run nox for ${{ matrix.python-version }}"
         run: |
-          nox -db uv -s test-${{ matrix.python-version }} -- -m 'not internet' --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov ensembl_tui
+          nox -db uv --force-python python -s test -- -m 'not internet' --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov ensembl_tui
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -46,6 +46,7 @@ class FeatureDataMixin:  # supports getitem as a dict on properties
 @dataclasses.dataclass(slots=True)
 class FeatureDataBase(FeatureDataMixin):
     seqid: str = dataclasses.field(kw_only=True)
+    coord_system_name: str = dataclasses.field(kw_only=True)
     start: int = dataclasses.field(kw_only=True)
     stop: int = dataclasses.field(kw_only=True)
     spans: numpy.ndarray[numpy.int32] = dataclasses.field(kw_only=True)
@@ -400,6 +401,7 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         columns = (
             "transcript_id",
             "seqid",
+            "coord_system_name",
             "start",
             "stop",
             "strand",
@@ -487,6 +489,7 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         columns = (
             "transcript_id",
             "seqid",
+            "coord_system_name",
             "start",
             "stop",
             "strand",
@@ -516,6 +519,7 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         columns = (
             "transcript_id",
             "seqid",
+            "coord_system_name",
             "start",
             "stop",
             "strand",
@@ -565,6 +569,7 @@ class GeneView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
         columns = (
             "transcript_id",
             "seqid",
+            "coord_system_name",
             "start",
             "stop",
             "strand",
@@ -710,6 +715,7 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
                     SELECT 
                         rc.repeat_type AS repeat_type,
                         sr.name AS seqid,
+                        cs.name AS coord_system_name,
                         rc.repeat_class AS repeat_class,
                         rc.repeat_name AS repeat_name,
                         rf.seq_region_start AS start,
@@ -718,6 +724,7 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
                     FROM repeat_consensus rc
                     JOIN repeat_feature rf ON rc.repeat_consensus_id = rf.repeat_consensus_id
                     JOIN seq_region sr ON rf.seq_region_id = sr.seq_region_id
+                    JOIN coord_system cs ON sr.coord_system_id = cs.coord_system_id
                     """
             self._conn.sql(sql)
         return self._conn
@@ -752,7 +759,7 @@ class RepeatView(eti_storage.DuckdbParquetBase, eti_storage.ViewMixin):
             if k not in ("self", "kwargs", "limit", "local_vars", "name", "biotype")
             and v is not None
         }
-        core_cols = "seqid", "start", "stop", "strand"
+        core_cols = "seqid", "start", "stop", "strand", "coord_system_name"
         repeat_cols = "repeat_type", "repeat_class", "repeat_name"
         if kwargs := {k: v for k, v in local_vars.items() if v is not None}:
             like_conds = {k: v for k, v in kwargs.items() if k in repeat_cols}

--- a/src/ensembl_tui/_ingest_annotation.py
+++ b/src/ensembl_tui/_ingest_annotation.py
@@ -308,7 +308,8 @@ def make_combined_tables(
     )
     preserve = (
         "seq_region",
-    )  # keep this one separate as we need to keep it for repeats
+        "coord_system",
+    )  # keep these one separate as we need them for repeats
     # checks these tables already exist in parquet format, fails otherwise
     conn = _make_db(config, db_name, transcribed_tables + preserve)
     _ = make_transcript_attr(con=conn)

--- a/src/ensembl_tui/_mysql_core_attr.py
+++ b/src/ensembl_tui/_mysql_core_attr.py
@@ -14,6 +14,7 @@ TRANSCRIPT_ATTR_SCHEMA = (
     "gene_id INTEGER",
     "transcript_id INTEGER",
     "seqid TEXT",
+    "coord_system_name TEXT",
     "start INTEGER",
     "stop INTEGER",
     "strand TINYINT",
@@ -28,6 +29,7 @@ GENE_ATTR_COLUMNS = (
     "stable_id",
     "biotype",
     "seqid",
+    "coord_system_name",
     "start",
     "stop",
     "strand",
@@ -75,7 +77,9 @@ def load_db(db_name: pathlib.Path, table_names: set[str]) -> duckdb.DuckDBPyConn
 
 location_attrs = {
     "location": "seq_region",
+    "coord_system": "coord_system",
 }
+
 gene_attrs = {
     "stableid": "gene",
     "symbol": "xref",
@@ -217,6 +221,7 @@ class TranscriptAttrRecord:
     transcript_id: int
     gene_id: int
     seqid: str
+    coord_system_name: str
     strand: int
     transcript_spans: numpy.ndarray
     cds_spans: numpy.ndarray | None
@@ -242,6 +247,7 @@ class TranscriptAttrRecord:
             "transcript_id": self.transcript_id,
             "gene_id": self.gene_id,
             "seqid": self.seqid,
+            "coord_system_name": self.coord_system_name,
             "start": int(self.start),
             "stop": int(self.stop),
             "strand": int(self.strand),
@@ -268,7 +274,7 @@ def get_transcript_attr_records(
     # we use SQL aggregate functions followed by numpy.fromstring to
     # greatly speedup extraction of all exon coords
     sql = """SELECT
-    transcript_id, gene_id, strand, seqid,
+    transcript_id, gene_id, strand, seqid, coord_system_name,
     transcript_stable_id, cds_stable_id,
     transcript_biotype,
     STRING_AGG(CAST(start AS VARCHAR), ' ') AS agg_start,
@@ -278,7 +284,7 @@ def get_transcript_attr_records(
     STRING_AGG(CAST(end_phase AS VARCHAR), ' ') AS agg_end_phase
     FROM exon_view
     GROUP BY transcript_id, gene_id, strand, seqid,
-    transcript_stable_id, cds_stable_id, transcript_biotype
+    coord_system_name, transcript_stable_id, cds_stable_id, transcript_biotype
     """
     limit_exons = get_all_limit_exons(conn)
     for (
@@ -286,6 +292,7 @@ def get_transcript_attr_records(
         gene_id,
         strand,
         seqid,
+        coord_system_name,
         transcript_stable_id,
         cds_stable_id,
         transcript_biotype,
@@ -316,6 +323,7 @@ def get_transcript_attr_records(
             # no translated exons
             yield TranscriptAttrRecord(
                 seqid=seqid,
+                coord_system_name=coord_system_name,
                 transcript_id=transcript_id,
                 gene_id=gene_id,
                 strand=strand,
@@ -342,6 +350,7 @@ def get_transcript_attr_records(
 
             yield TranscriptAttrRecord(
                 seqid=seqid,
+                coord_system_name=coord_system_name,
                 transcript_id=transcript_id,
                 gene_id=gene_id,
                 strand=strand,
@@ -385,6 +394,7 @@ def get_transcript_attr_records(
 
         yield TranscriptAttrRecord(
             seqid=seqid,
+            coord_system_name=coord_system_name,
             transcript_id=transcript_id,
             gene_id=gene_id,
             strand=strand,
@@ -405,6 +415,7 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
             et.transcript_id AS transcript_id,
             ex.exon_id AS exon_id,
             sr.name AS seqid,
+            cs.name AS coord_system_name,
             ex.seq_region_start AS start,
             ex.seq_region_end AS stop,
             ex.seq_region_strand AS strand,
@@ -417,6 +428,7 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
             tl.stable_id as cds_stable_id,
         FROM exon ex
         JOIN seq_region sr ON ex.seq_region_id = sr.seq_region_id
+        JOIN coord_system cs ON sr.coord_system_id = cs.coord_system_id
         JOIN exon_transcript et ON ex.exon_id = et.exon_id
         JOIN transcript tr ON et.transcript_id = tr.transcript_id
         LEFT JOIN translation tl ON tr.transcript_id = tl.transcript_id
@@ -439,13 +451,15 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
 
 def make_gene_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
     """creates a gene_attr 'table' from several other tables"""
+    # need to also add coord_system_name to the gene_attr table
     sql = """CREATE VIEW IF NOT EXISTS gene_attr AS
-        SELECT 
+        SELECT
             g.gene_id AS gene_id,
             g.stable_id AS stable_id,
             g.biotype AS biotype,
             g.canonical_transcript_id AS canonical_transcript_id,
             sr.name AS seqid,
+            cs.name AS coord_system_name,
             g.seq_region_start AS start,
             g.seq_region_end AS stop,
             g.seq_region_strand AS strand,
@@ -453,6 +467,7 @@ def make_gene_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
             g.description as description,
         FROM gene g
         JOIN seq_region sr ON g.seq_region_id = sr.seq_region_id
+        JOIN coord_system cs ON sr.coord_system_id = cs.coord_system_id
         LEFT JOIN xref x ON g.display_xref_id = x.xref_id
         """
     con.sql(sql)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def DATA_DIR():
 
 @pytest.fixture(scope="session")
 def ENSEMBL_RELEASE_VERSION() -> str:
-    return "113"
+    return "114"
 
 
 @pytest.fixture
@@ -50,8 +50,8 @@ def namer():
     return name_as_seqid
 
 
-TEST_DATA_URL = "https://www.dropbox.com/scl/fi/pfmwzz96gusdeqi0a9wax/small-113.zip?rlkey=r60l1eq9jk6p440tkqslmqihi&st=ud49fits&dl=1"
-SMALL_DATA_DIRNAME = "small-113"
+TEST_DATA_URL = "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+SMALL_DATA_DIRNAME = "small-114"
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/small.cfg
+++ b/tests/data/small.cfg
@@ -2,10 +2,10 @@
 host=ftp.ensembl.org
 path=pub
 [local path]
-staging_path=small-113/download
-install_path=small-113/install
+staging_path=small-114/download
+install_path=small-114/install
 [release]
-release=113
+release=114
 [Saccharomyces cerevisiae]
 db=core
 [Caenorhabditis elegans]

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -16,6 +16,7 @@ def make_gene_attr(records: list[dict]) -> eti_annots.GeneView:
         "stable_id TEXT",
         "biotype TEXT",
         "seqid TEXT",
+        "coord_system_name TEXT",
         "start INTEGER",
         "stop INTEGER",
         "strand TINYINT",
@@ -28,7 +29,7 @@ def make_gene_attr(records: list[dict]) -> eti_annots.GeneView:
     sql = f"""CREATE TABLE IF NOT EXISTS gene_attr ({",".join(schema)})"""
     conn = duckdb.connect(":memory:")
     conn.sql(sql)
-    sql = "INSERT INTO gene_attr VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    sql = "INSERT INTO gene_attr VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     rows = [[r.get(c) for c in columns] for r in records]
     conn.executemany(sql, parameters=rows)
     return eti_annots.GeneView(source=":memory:", db=conn)
@@ -40,6 +41,7 @@ def get_annotation_db() -> dict[str, eti_annots.Annotations]:
             [
                 {
                     "seqid": "s1",
+                    "coord_system_name": "chromosome",
                     "biotype": "protein_coding",
                     "stable_id": "not-on-s2",
                     "start": 4,
@@ -51,6 +53,7 @@ def get_annotation_db() -> dict[str, eti_annots.Annotations]:
             [
                 {
                     "seqid": "s2",
+                    "coord_system_name": "chromosome",
                     "biotype": "protein_coding",
                     "stable_id": "includes-s2-gap",
                     "start": 2,
@@ -62,6 +65,7 @@ def get_annotation_db() -> dict[str, eti_annots.Annotations]:
             [
                 {
                     "seqid": "s3",
+                    "coord_system_name": "chromosome",
                     "biotype": "protein_coding",
                     "stable_id": "includes-s3-gap",
                     "start": 22,

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -173,6 +173,7 @@ def test_convert_to_dict():
 
     raw = {
         "seqid": "I",
+        "coord_system_name": "chromosome",
         "start": 11701629,
         "stop": 11703698,
         "spans": numpy.array(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -24,6 +24,7 @@ EXON_VIEW_SCHEMA = (
     "transcript_id INTEGER",
     "exon_id INTEGER",
     "seqid TEXT",
+    "coord_system_name TEXT",
     "start INTEGER",
     "stop INTEGER",
     "strand TINYINT",
@@ -40,10 +41,19 @@ EXON_VIEW_COLS = [c.split()[0] for c in EXON_VIEW_SCHEMA]
 
 SEQ_REGION_SCHEMA = (
     "seq_region_id INTEGER",
+    "coord_system_id INTEGER",
     "name TEXT",
 )
 
 SEQ_REGION_COLS = [c.split()[0] for c in SEQ_REGION_SCHEMA]
+
+COORD_SYSTEM_SCHEMA = (
+    "coord_system_id INTEGER",
+    "name TEXT",
+    "rank INTEGER",
+)
+
+COORD_SYSTEM_COLS = [c.split()[0] for c in COORD_SYSTEM_SCHEMA]
 
 EXON_SCHEMA = (
     "exon_id INTEGER",
@@ -172,8 +182,9 @@ def test_install_features(yeast_db):
     # this is a check on expectations rather than execution
     source = yeast_db.source
     pqts = list(source.glob("*.parquet"))
-    # tables are seq_region, repeat, repeat_consensus, gene_attr, transcript_attr
-    assert len(pqts) == 5
+    # tables are coord_system, seq_region, repeat, repeat_consensus,
+    # gene_attr, transcript_attr
+    assert len(pqts) == 6
 
 
 # fail to import if directories or files are missing
@@ -287,6 +298,7 @@ def four_exons(empty_ev_tr):
             "transcript_id": 11,
             "exon_id": 1,
             "seqid": "2",
+            "coord_system_name": "chromosome",
             "start": 100,
             "stop": 200,
             "strand": 1,
@@ -301,6 +313,7 @@ def four_exons(empty_ev_tr):
             "transcript_id": 11,
             "exon_id": 2,
             "seqid": "2",
+            "coord_system_name": "chromosome",
             "start": 300,
             "stop": 400,
             "strand": 1,
@@ -315,6 +328,7 @@ def four_exons(empty_ev_tr):
             "transcript_id": 11,
             "exon_id": 3,
             "seqid": "2",
+            "coord_system_name": "chromosome",
             "start": 500,
             "stop": 600,
             "strand": 1,
@@ -329,6 +343,7 @@ def four_exons(empty_ev_tr):
             "transcript_id": 11,
             "exon_id": 4,
             "seqid": "2",
+            "coord_system_name": "chromosome",
             "start": 700,
             "stop": 800,
             "strand": 1,
@@ -514,12 +529,14 @@ def test_no_cds_spans(four_exons):
     assert tr.cds_spans is None
     record = tr.to_record(eti_tables.TRANSCRIPT_ATTR_COLS)
     assert record[-4] is None
-    assert len(record) == 11
+    assert len(record) == len(eti_tables.TRANSCRIPT_ATTR_COLS)
 
 
 def single_tables_db():
     conn = duckdb.connect()
     sql = f"CREATE TABLE seq_region ({', '.join(SEQ_REGION_SCHEMA)})"
+    conn.execute(sql)
+    sql = f"CREATE TABLE coord_system ({', '.join(COORD_SYSTEM_SCHEMA)})"
     conn.execute(sql)
     sql = f"CREATE TABLE exon ({', '.join(EXON_SCHEMA)})"
     conn.execute(sql)
@@ -536,10 +553,17 @@ def single_tables_db():
 def mixed_data():
     conn = single_tables_db()
     # seq_region: seq_region_id, name
-    sr_data = [{"seq_region_id": i, "name": str(i)} for i in range(1, 3)]
+    sr_data = [
+        {"seq_region_id": i, "name": str(i), "coord_system_id": 1} for i in range(1, 3)
+    ]
     conn.executemany(
-        "INSERT INTO seq_region VALUES (?, ?)",
+        "INSERT INTO seq_region VALUES (?, ?, ?)",
         parameters=[[r[c] for c in SEQ_REGION_COLS] for r in sr_data],
+    )
+    # coordinate system: coord_system_id, name, rank
+    conn.execute(
+        "INSERT INTO coord_system VALUES (?, ?, ?)",
+        (1, "chromosome", 1),
     )
     exon_data = [
         {


### PR DESCRIPTION
## Summary by Sourcery

Add full support for the Ensembl core coordinate system table across ingestion, attribute loaders, and feature queries, and update tests and CI to target Ensembl release 114.

New Features:
- Introduce a coord_system table with coord_system_id and coord_system_name in schemas, ingestion logic, and attribute views.
- Extend core feature queries and data models to include coord_system_name by joining seq_region to coord_system.

Bug Fixes:
- Adjust test_install_features to expect six parquet tables instead of five.

Enhancements:
- Add coord_system_name field to FeatureDataBase and core column definitions.
- Bump default Ensembl release version to 114 and update test data paths and configuration.

CI:
- Update testing workflow cache keys and download URLs to use Ensembl release 114 data.

Tests:
- Update test schemas, fixtures, and assertions to seed and validate the new coord_system table and columns.