### PR TITLE
Major refactor of Genome

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-data-v4-${{ hashFiles('tests/data/small-114.zip') }}
+          key: ${{ runner.os }}-data-v5-${{ hashFiles('tests/data/small-114.zip') }}
           restore-keys: |
-            ${{ runner.os }}-data-v4-
+            ${{ runner.os }}-data-v5-
 
       - name: Check cache status
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,9 @@ dependencies = ["blosc2",
         "click",
         # following needs to be replaced by cogent3>=version when
         # cogent3 annotation db API changes are released
-        "cogent3 @ git+https://github.com/cogent3/cogent3.git@develop",
+        "cogent3",
+        "cogent3-h5seqs",
         "duckdb",
-        "h5py",
-        "hdf5plugin",
         "numba",
         "numpy",
         "rich",

--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -207,12 +207,12 @@ class AlignDb(eti_storage.DuckdbParquetBase):
 
 def get_alignment(
     align_db: AlignDb,
-    genomes: dict[str, eti_genome.Genome],
+    genomes: dict[str, c3_align.SequenceCollection],
     ref_species: str,
     seqid: str,
     ref_start: int | None = None,
     ref_end: int | None = None,
-    namer: typing.Callable | None = None,
+    namer: typing.Callable[[str, str, int, int], str] | None = None,
     mask_features: list[str] | None = None,
     shadow: bool = False,
     mask_ref: bool = False,
@@ -303,13 +303,17 @@ def get_alignment(
                 # if it's neg strand, the alignment start is the genome stop
                 seq_start = imap.parent_length - seq_end
 
-            s = genome.get_seq(
-                seqid=align_record.seqid,
-                start=genome_start + seq_start,
-                stop=genome_start + seq_start + seq_length,
-                namer=namer,
-                with_annotations=False,
-            )
+            start = genome_start + seq_start
+            stop = genome_start + seq_start + seq_length
+            s = genome.seqs[align_record.seqid][start:stop]
+
+            if namer:
+                name = namer(align_record.species, align_record.seqid, start, stop)
+            else:
+                name = f"{align_record.species}:{align_record.seqid}:{start}-{stop}"
+
+            s.name = name
+            s.replace_annotation_db(None)
             # we now trim the gaps for this sequence to the sub-alignment
             imap = imap[align_start:align_end]
 
@@ -366,7 +370,7 @@ class construct_alignment:  # noqa: N801
     def __init__(
         self,
         align_db: AlignDb,
-        genomes: dict[str, eti_genome.Genome],
+        genomes: dict[str, c3_align.SequenceCollection],
         mask_features: list[str] | None = None,
         shadow: bool = False,
         mask_ref: bool = False,

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -895,6 +895,24 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
         if self.repeats:
             self.repeats.close()
 
+    def get_ids_for_biotype(
+        self,
+        *,
+        biotype: str,
+        seqid: str | list[str] | None = None,
+        limit: int | None = None,
+    ) -> typing.Iterable[str]:
+        if self.genes is None:
+            msg = f"no gene data for {self.species}"
+            raise ValueError(msg)
+        seqids = [seqid] if isinstance(seqid, str | type(None)) else seqid
+        for seqid in seqids:
+            yield from self.genes.get_ids_for_biotype(
+                biotype=biotype,
+                seqid=seqid,
+                limit=limit,
+            )
+
 
 @dataclasses.dataclass(frozen=True)
 class species_seqid:

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -1,38 +1,27 @@
 import dataclasses
-import functools
 import pathlib
 import sys
 import typing
-import uuid
-from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any
 
 import cogent3
-import h5py
+import cogent3_h5seqs as c3h5
 import numpy
 from cogent3.app.composable import define_app
 from cogent3.core import new_alphabet
-from cogent3.core.annotation import Feature
-from cogent3.core.annotation_db import (
-    OptionalInt,
-    OptionalStr,
-)
 from cogent3.core.new_sequence import Sequence
 from cogent3.core.table import Table
 from cogent3.parse.fasta import iter_fasta_records
-from numpy.typing import NDArray
 
 import ensembl_tui._annotation as eti_annots
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _species as eti_species
-from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
 
-SEQ_STORE_NAME = "genome.seqs-hdf5_blosc2"
+SEQ_STORE_NAME = f"genome-seqs.{c3h5.UNALIGNED_SUFFIX}"
 
 DNA = cogent3.get_moltype("dna", new_type=True)
-alphabet = DNA.most_degen_alphabet()
+alphabet = DNA.most_degen_alphabet()  # type: ignore  # noqa: PGH003
 bytes_to_array = new_alphabet.bytes_to_array(
     chars=alphabet.as_bytes(),
     dtype=numpy.uint8,
@@ -57,13 +46,20 @@ class fasta_to_hdf5:  # noqa: N801
     def main(self, db_name: str) -> bool:
         src_dir = self.config.staging_genomes / db_name
         dest_dir = self.config.install_genomes / db_name
-
-        seq_store = SeqsDataHdf5(
-            source=dest_dir / SEQ_STORE_NAME,
-            species=eti_species.Species.get_species_name(db_name),
-            mode="w",
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        out_path = dest_dir / SEQ_STORE_NAME
+        # we directly use the cogent3_h5seqs library to create the
+        # unaligned hdf5 file. This library is valid storage for
+        # cogent3 collections
+        alpha = cogent3.get_moltype("dna", new_type=True).most_degen_alphabet()
+        seq_store = c3h5.make_unaligned(out_path, alphabet=alpha, mode="w")
+        seq_store.set_attr(
+            "species",
+            # we have to coerce the species name from a case insensitive string
+            # to a standard python string
+            str(eti_species.Species.get_species_name(db_name)),
+            force=True,
         )
-
         src_dir = src_dir / "fasta"
         for path in src_dir.glob("*.fa.gz"):
             for seqid, seq in iter_fasta_records(
@@ -71,200 +67,12 @@ class fasta_to_hdf5:  # noqa: N801
                 converter=bytes_to_array,
                 label_to_name=self.label_to_name,
             ):
-                seq_store.add_record(seq, seqid)
+                seq_store.add_seqs({seqid: seq}, force_unique_keys=False)
                 del seq
 
         seq_store.close()
 
         return True
-
-
-T = tuple[eti_util.PathType, list[tuple[str, str]]]
-
-
-class SeqsDataABC(ABC):
-    """interface for genome sequence storage"""
-
-    # the storage reference, e.g. path to file
-    source: eti_util.PathType
-    species: str
-    mode: str  # as per standard file opening modes, r, w, a
-    _is_open = False
-    _file: Any | None = None
-
-    @abstractmethod
-    def __hash__(self) -> int: ...
-
-    @abstractmethod
-    def add_record(self, seq: str, seqid: str) -> None: ...
-
-    @abstractmethod
-    def add_records(self, *, records: typing.Iterable[list[str, str]]) -> None: ...
-
-    @abstractmethod
-    def get_seq_str(
-        self,
-        *,
-        seqid: str,
-        start: int | None = None,
-        stop: int | None = None,
-    ) -> str: ...
-
-    @abstractmethod
-    def get_seq_arr(
-        self,
-        *,
-        seqid: str,
-        start: int | None = None,
-        stop: int | None = None,
-    ) -> NDArray[numpy.uint8]: ...
-
-    @abstractmethod
-    def get_coord_names(self) -> tuple[str]: ...
-
-    @abstractmethod
-    def close(self) -> None: ...
-
-
-@define_app
-class str2arr:  # noqa: N801
-    """convert string to array of uint8"""
-
-    def __init__(self, moltype: str = "dna", max_length: int | None = None) -> None:
-        mt = cogent3.get_moltype(moltype, new_type=True)
-        self.alphabet = mt.most_degen_alphabet()
-        self.max_length = max_length
-
-    def main(self, data: str) -> numpy.ndarray:
-        if self.max_length:
-            data = data[: self.max_length]
-
-        return self.alphabet.to_indices(data)
-
-
-@define_app
-class arr2str:  # noqa: N801
-    """convert array of uint8 to str"""
-
-    def __init__(self, moltype: str = "dna", max_length: int | None = None) -> None:
-        mt = cogent3.get_moltype(moltype, new_type=True)
-        self.alphabet = mt.most_degen_alphabet()
-        self.max_length = max_length
-
-    def main(self, data: numpy.ndarray) -> str:
-        if self.max_length:
-            data = data[: self.max_length]
-        return self.alphabet.from_indices(data)
-
-
-@dataclasses.dataclass
-class SeqsDataHdf5(eti_storage.Hdf5Mixin, SeqsDataABC):
-    """HDF5 sequence data storage"""
-
-    def __init__(
-        self,
-        source: eti_util.PathType,
-        species: str | None = None,
-        mode: str = "r",
-        in_memory: bool = False,
-    ) -> None:
-        # note that species are converted into the Ensembl db prefix
-        in_memory = in_memory or "memory" in str(source)
-        source = uuid.uuid4().hex if in_memory else source
-        self.source = pathlib.Path(source)
-
-        if not in_memory and mode == "r" and not self.source.exists():
-            msg = f"{self.source!s} not found"
-            raise OSError(msg)
-
-        species = (
-            eti_species.Species.get_ensembl_db_prefix(species) if species else None
-        )
-        self.mode = "w-" if mode == "w" else mode
-        h5_kwargs = (
-            {
-                "driver": "core",
-                "backing_store": False,
-            }
-            if in_memory
-            else {}
-        )
-        try:
-            self._file: h5py.File = h5py.File(source, mode=self.mode, **h5_kwargs)
-        except OSError:
-            print(source)
-            raise
-        self._str2arr = str2arr(moltype="dna")
-        self._arr2str = arr2str(moltype="dna")
-        self._is_open = True
-        if "r" not in self.mode and "species" not in self._file.attrs:
-            assert species
-            self._file.attrs["species"] = species
-
-        if (
-            species
-            and (file_species := self._file.attrs.get("species", None)) != species
-        ):
-            msg = f"{self.source.name!r} {file_species!r} != {species}"
-            raise ValueError(msg)
-        self.species = self._file.attrs["species"]
-
-    def __hash__(self) -> int:
-        return id(self)
-
-    @functools.singledispatchmethod
-    def add_record(self, seq: str, seqid: str) -> None:
-        seq = self._str2arr(seq)
-        self.add_record(seq, seqid)
-
-    @add_record.register
-    def _(self, seq: numpy.ndarray, seqid: str) -> None:
-        if seqid in self._file:
-            stored = self._file[seqid]
-            if (seq == stored).all():
-                # already seen this seq
-                return
-            # but it's different, which is a problem
-            num_diffs = (seq != stored).sum()
-            msg = f"{seqid!r} already present but with different seq {num_diffs=}"
-            raise ValueError(msg)
-
-        self._file.create_dataset(
-            name=seqid,
-            data=seq,
-            chunks=True,
-            **eti_util.HDF5_BLOSC2_KWARGS,
-        )
-
-    def add_records(self, *, records: typing.Iterable[list[str, str]]) -> None:
-        for seqid, seq in records:
-            self.add_record(seq, seqid)
-
-    def get_seq_str(
-        self,
-        *,
-        seqid: str,
-        start: int | None = None,
-        stop: int | None = None,
-    ) -> str:
-        return self._arr2str(self.get_seq_arr(seqid=seqid, start=start, stop=stop))
-
-    def get_seq_arr(
-        self,
-        *,
-        seqid: str,
-        start: int | None = None,
-        stop: int | None = None,
-    ) -> NDArray[numpy.uint8]:
-        if not self._is_open:
-            msg = f"{self.source.name!r} is closed"
-            raise OSError(msg)
-
-        return self._file[seqid][start:stop]
-
-    def get_coord_names(self) -> tuple[str]:
-        """names of chromosomes / contig"""
-        return tuple(self._file)
 
 
 @dataclasses.dataclass(slots=True)
@@ -288,175 +96,19 @@ class genome_segment:  # noqa: N801
         return self.unique_id
 
 
-# TODO: this wrapping class is required for memory efficiency because
-#  the cogent3 SequenceCollection class is not designed for large sequence
-#  collections, either large sequences or large numbers of sequences. The
-#  longer term solution is improving SequenceCollections,
-#  which is underway 🎉
-class Genome:
-    """class to be replaced by cogent3 sequence collection when that
-    has been modernised"""
-
-    def __init__(
-        self,
-        *,
-        species: str,
-        seqs: SeqsDataABC,
-        annots: eti_annots.Annotations,
-    ) -> None:
-        self.species = species
-        self._seqs = seqs
-        self.annotation_db = annots
-
-    @property
-    def seqs(self) -> SeqsDataABC:
-        return self._seqs
-
-    def get_seq(
-        self,
-        *,
-        seqid: str,
-        start: int | None = None,
-        stop: int | None = None,
-        namer: typing.Callable | None = None,
-        with_annotations: bool = True,
-    ) -> Sequence:
-        """returns annotated sequence
-
-        Parameters
-        ----------
-        seqid
-            name of chromosome etc..
-        start
-            starting position of slice in python coordinates, defaults
-            to 0
-        stop
-            ending position of slice in python coordinates, defaults
-            to length of coordinate
-        namer
-            callback for naming the sequence. Callback must take four
-            arguments: species, seqid,start, stop. Default is
-            species:seqid:start-stop.
-        with_annotations
-            assign annotation_db to seq
-
-        Notes
-        -----
-        Full annotations are bound to the instance.
-        """
-        seq = self._seqs.get_seq_arr(seqid=seqid, start=start, stop=stop)
-        if namer:
-            name = namer(self.species, seqid, start, stop)
-        else:
-            name = f"{self.species}:{seqid}:{start}-{stop}"
-        # we use seqid to make the sequence here because that identifies the
-        # parent seq identity, required for querying annotations
-        seq = cogent3.make_seq(
-            seq,
-            name=seqid,
-            moltype="dna",
-            annotation_offset=start or 0,
-            new_type=True,
-        )
-        seq.name = name
-        seq.annotation_db = self.annotation_db if with_annotations else None
-        return seq
-
-    def get_features(
-        self,
-        *,
-        biotype: OptionalStr = None,
-        seqid: OptionalStr = None,
-        name: OptionalStr = None,
-        start: OptionalInt = None,
-        stop: OptionalInt = None,
-        limit: OptionalInt = None,
-        canonical: bool = True,
-    ) -> typing.Iterable[Feature]:
-        for ft in self.annotation_db.get_features_matching(
-            biotype=biotype,
-            seqid=seqid,
-            stable_id=name,
-            start=start,
-            stop=stop,
-            limit=limit,
-            canonical=canonical,
-        ):
-            seqid = ft.seqid
-            ft.spans = numpy.array(ft.spans)
-            start = int(ft.spans.min())
-            stop = int(ft.spans.max())
-            ft.spans = ft.spans - start
-            # cogent3 only handles strand as a string
-            ft.strand = "-" if ft.strand == -1 else "+"
-            seq = self.get_seq(
-                seqid=seqid,
-                start=start,
-                stop=stop,
-                with_annotations=True,
-            )
-            # because self.get_seq() automatically names seqs differently
-            seq.name = seqid
-            yield seq.make_feature(ft)
-
-    def _get_cds(
-        self,
-        *,
-        stable_id: str,
-        biotype: str = "protein_coding",
-    ) -> typing.Iterable[Feature]:
-        gene = next(
-            iter(
-                self.annotation_db.get_features_matching(
-                    stable_id=stable_id,
-                    biotype=biotype,
-                ),
-            ),
-        )
-        cds = self.annotation_db.get_cds(gene=gene)
-        seq = self.get_seq(seqid=cds.seqid, start=cds.start, stop=cds.stop)
-        cds["spans"] = cds["spans"] - cds.start
-        data = dict(cds)
-        data.pop("xattr", None)
-        # cogent3 currently only handles character data for strand
-        data["strand"] = "-" if data.get("strand") == -1 else "+"
-
-        try:
-            yield seq.make_feature(feature=data)
-        except ValueError:
-            msg = f"invalid location data for {cds!r}"
-            raise ValueError(msg)
-
-    def get_ids_for_biotype(
-        self,
-        *,
-        biotype: str,
-        seqid: str | list[str] | None = None,
-        limit: OptionalInt = None,
-    ) -> typing.Iterable[str]:
-        genes = self.annotation_db.genes
-        if genes is None:
-            msg = f"no gene data for {self.species}"
-            raise ValueError(msg)
-        seqids = [seqid] if isinstance(seqid, str | type(None)) else seqid
-        for seqid in seqids:
-            yield from genes.get_ids_for_biotype(
-                biotype=biotype,
-                seqid=seqid,
-                limit=limit,
-            )
-
-    def close(self) -> None:
-        self._seqs.close()
-        self.annotation_db.close()
-
-
-def load_genome(*, config: eti_config.InstalledConfig, species: str) -> Genome:
-    """returns the Genome with bound seqs and features"""
+def load_genome(*, config: eti_config.InstalledConfig, species: str):
+    """returns the genome with annotations"""
     genome_path = config.installed_genome(species) / SEQ_STORE_NAME
-    seqs = SeqsDataHdf5(source=genome_path, species=species, mode="r")
+    storage = c3h5.load_seqs_data_unaligned(genome_path)
+    dna = cogent3.get_moltype("dna", new_type=True)
     ann = eti_annots.Annotations(source=config.installed_genome(species))
-    return Genome(species=species, seqs=seqs, annots=ann)
+    return cogent3.make_unaligned_seqs(
+        storage,
+        moltype=dna,
+        annotation_db=ann,
+        info={"species": species},
+        new_type=True,
+    )
 
 
 def get_seqs_for_ids(
@@ -468,9 +120,11 @@ def get_seqs_for_ids(
 ) -> typing.Iterable[Sequence]:
     genome = load_genome(config=config, species=species)
     # is it possible to do batch query for all names?
+    ann_db = genome.annotation_db
+
     for name in names:
         cds = list(
-            genome.get_features(
+            ann_db.get_features_matching(
                 name=name,
                 biotype="cds",
                 canonical=True,
@@ -479,7 +133,7 @@ def get_seqs_for_ids(
         if not cds:
             continue
 
-        feature = cds[0]
+        feature = genome.make_feature(feature=cds[0])
         seq = feature.get_slice()
         if callable(make_seq_name):
             seq.name = make_seq_name(feature)
@@ -492,7 +146,6 @@ def get_seqs_for_ids(
         seq.annotation_db = None
         yield seq
 
-    genome.close()
     del genome
 
 

--- a/src/ensembl_tui/_ingest_annotation.py
+++ b/src/ensembl_tui/_ingest_annotation.py
@@ -4,7 +4,6 @@ import shutil
 from collections.abc import Generator
 
 import duckdb
-import rich.progress as rich_progress
 from cogent3.app.composable import LOADER, define_app
 
 from ensembl_tui import _config as eti_config
@@ -32,7 +31,7 @@ def show_some_data(
     con: duckdb.DuckDBPyConnection,
     table_name: str,
     limit: int = 5,
-) -> None:
+) -> None:  # pragma: no cover
     # this is a useful function for debugging
     sql = f"SELECT * FROM {table_name} LIMIT {limit}"
     print(table_name, con.sql(sql), sep="\n")  # noqa: T201
@@ -334,75 +333,6 @@ def make_combined_tables(
             (config.install_genomes / db_name / f"{table_name}.parquet").unlink(
                 missing_ok=True,
             )
-
-
-def install_parquet_tables(
-    config: eti_config.Config,
-    progress: rich_progress.Progress | None = None,
-    make_combined: bool = True,
-) -> pathlib.Path:
-    """installs annotation data as parquet files
-
-    Parameters
-    ----------
-    config
-        a config instance from a downloaded.cfg file
-    progress
-        rich Progress instance
-    make_combined
-        makes the combined attr tables, for testing purposes only!
-
-    Returns
-    -------
-    The path to the installed genomes directory.
-    """
-    template_dir = config.staging_template_path
-    if not template_dir.exists():
-        msg = f"no mysql dump dir for {template_dir}"
-        raise FileNotFoundError(msg)
-
-    dump_root = config.staging_genomes
-    genome_root = config.install_genomes
-    genome_root.mkdir(parents=True, exist_ok=True)
-    table_names = [fn.stem for fn in template_dir.glob("*.duckdb")]
-    if progress is not None:
-        msg = "Installing features 📚"
-        num_genomes = len(config.species_dbs)
-        num_tables = len(table_names)
-        writing = progress.add_task(total=num_genomes * num_tables, description=msg)
-
-    for db_name in config.db_names:
-        dump_dir = dump_root / db_name / "mysql"
-        if not dump_dir.exists():
-            msg = f"no mysql dump dir for {db_name}"
-            raise FileNotFoundError(msg)
-
-        dest_dir = genome_root / db_name
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        for table_name in table_names:
-            dump_path = dump_dir / f"{table_name}.txt.gz"
-            if not dump_path.exists():
-                msg = f"no mysqldump file for {table_name}"
-                raise FileNotFoundError(msg)
-
-            write_parquet(
-                db_templates=template_dir,
-                dump_path=dump_path,
-                table_name=table_name,
-                dest_dir=dest_dir,
-                # the translation table has 2 columns that need the
-                # correction to 0-based, that coercion will be done in the
-                # merging tables function
-                fix_start=table_name != "translation",
-            )
-            if progress is not None:
-                progress.update(writing, advance=1)
-
-        # and now we construct the combined attr tables
-        if make_combined:
-            make_combined_tables(config=config, db_name=db_name, cleanup=True)
-
-    return genome_root
 
 
 @define_app(app_type=LOADER)

--- a/src/ensembl_tui/_storage_mixin.py
+++ b/src/ensembl_tui/_storage_mixin.py
@@ -1,16 +1,11 @@
-import contextlib
 import dataclasses
 import functools
 import io
-import os
 import pathlib
 
 import duckdb
-import h5py
 import numpy
 import typing_extensions
-
-from ensembl_tui import _util as eti_util
 
 ReturnType = tuple[str, tuple]  # the sql statement and corresponding values
 
@@ -39,59 +34,6 @@ def blob_to_array(data: bytes) -> numpy.ndarray:
 @blob_to_array.register
 def _(data: numpy.ndarray) -> numpy.ndarray:
     return data
-
-
-# HDF5 base class
-@dataclasses.dataclass
-class Hdf5Mixin(eti_util.SerialisableMixin):
-    """HDF5 sequence data storage"""
-
-    _file: h5py.File | None = None
-    _is_open: bool = False
-    mode: str = "r"
-
-    def __getstate__(self) -> dict:
-        if set(self.mode) & {"w", "a"}:
-            raise NotImplementedError(f"pickling not supported for mode={self.mode!r}")
-        return self._init_vals.copy()  # type: ignore
-
-    def __setstate__(self, state: dict) -> None:
-        obj = self.__class__(**state)
-        self.__dict__.update(obj.__dict__)
-        # because we have a __del__ method, and self attributes point to
-        # attributes on obj, we need to modify obj state so that garbage
-        # collection does not screw up self
-        obj._is_open = False
-        obj._file = None
-
-    def __del__(self) -> None:
-        self.close()
-
-    def close(self) -> None:
-        """closes the hdf5 file"""
-        # during garbage collection at shutdown, the open function is
-        # not available
-        try:
-            open  # noqa: B018
-        except NameError:
-            return
-
-        # hdf5 dumps content to stdout if resource already closed, so
-        # we trap that here, and capture expected exceptions raised in the process
-        with (
-            open(os.devnull, "w") as devnull,
-            contextlib.redirect_stderr(devnull),
-            contextlib.redirect_stdout(devnull),
-        ):
-            with contextlib.suppress(ValueError, AttributeError):
-                if self._is_open and self._file:
-                    self._file.flush()
-
-            with contextlib.suppress(AttributeError):
-                if self._file:
-                    self._file.close()
-
-        self._is_open = False
 
 
 class ViewMixin:

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -1,6 +1,5 @@
 import contextlib
 import functools
-import inspect
 import os
 import pathlib
 import re
@@ -423,22 +422,6 @@ def sanitise_stableid(stableid: str) -> str:
     this function removes redundant biotype component.
     """
     return _biotypes.sub("", stableid)
-
-
-class SerialisableMixin:
-    """mixin class, adds a self._init_vals dict attribute which
-    contains the keyword/arg mapping of arguments provided to the
-    constructor"""
-
-    def __new__(cls, *args, **kwargs):
-        obj = object.__new__(cls)
-        init_sig = inspect.signature(cls.__init__)
-        bargs = init_sig.bind_partial(cls, *args, **kwargs)
-        bargs.apply_defaults()
-        init_vals = bargs.arguments
-        init_vals.pop("self", None)
-        obj._init_vals = init_vals
-        return obj
 
 
 _quotes = re.compile(r"^[\'\"]|[\'\"]$")

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -379,7 +379,7 @@ def homologs(
     # to be the number of homology matches
     if not ref_genes:
         ref_genes = list(
-            genome.get_ids_for_biotype(
+            genome.annotation_db.get_ids_for_biotype(
                 biotype="protein_coding",
                 seqid=coord_names,
             ),
@@ -562,7 +562,7 @@ def alignments(
     elif coord_names:
         genome = genomes[ref_species]
         stableids = list(
-            genome.get_ids_for_biotype(
+            genome.annotation_db.get_ids_for_biotype(
                 biotype="protein_coding",
                 seqid=coord_names,
                 limit=limit,

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -1,5 +1,7 @@
 import pickle
 
+import cogent3
+import cogent3_h5seqs as c3h5
 import duckdb
 import numpy
 import pytest
@@ -155,7 +157,7 @@ def test_aligndb_records_skip_duplicated_block_ids(small_records):
     assert agg.sql(sql).fetchone()[0] == count
 
 
-# fixture to make synthetic GenomeSeqsDb and alignment db
+# fixture to make synthetic genome and alignment db
 # based on a given alignment
 @pytest.fixture
 def genomedbs_aligndb(small_records):
@@ -167,17 +169,19 @@ def genomedbs_aligndb(small_records):
     data = seqs.to_dict()
     genomes = {}
     for name, seq in data.items():
-        genome = eti_genome.SeqsDataHdf5(
-            source=f"{name}",
-            species=species[name],
-            mode="w",
+        genome = c3h5.make_unaligned(
+            "memory",
             in_memory=True,
+            mode="w",
+            alphabet=eti_genome.alphabet,
         )
-        genome.add_records(records=[(name, seq)])
-        genomes[species[name]] = eti_genome.Genome(
-            seqs=genome,
-            annots=None,
-            species=species[name],
+        genome.add_seqs(seqs={name: seq})
+        genomes[species[name]] = cogent3.make_unaligned_seqs(
+            genome,
+            annotation_db=None,
+            info={"species": species[name]},
+            new_type=True,
+            moltype="dna",
         )
 
     return genomes, align_db
@@ -226,17 +230,20 @@ def make_sample(two_aligns=False):
         if seq.name == "s2":
             seq = seq.rc()
             s2_genome = str(seq)
-        genome = eti_genome.SeqsDataHdf5(
-            source=f"{name}",
-            mode="w",
+        genome = c3h5.make_unaligned(
+            "memory",
             in_memory=True,
-            species=species[seq.name],
+            mode="w",
+            alphabet=eti_genome.alphabet,
         )
-        genome.add_records(records=[(name, str(seq))])
-        genomes[species[name]] = eti_genome.Genome(
-            seqs=genome,
-            annots=annot_dbs[name],
-            species=species[name],
+        genome.add_seqs(seqs={name: str(seq)})
+
+        genomes[species[name]] = cogent3.make_unaligned_seqs(
+            genome,
+            annotation_db=annot_dbs[name],
+            info={"species": species[name]},
+            new_type=True,
+            moltype="dna",
         )
 
     # define two alignment blocks that incorporate features

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -268,3 +268,25 @@ def test_multi_species(multi_species_db):
     expect = dict(expect)
     expect["spans"] = expect["spans"].tolist()
     assert got == expect
+
+
+def test_get_ids_for_biotype2(yeast_db):
+    features = list(yeast_db.get_ids_for_biotype(biotype="rRNA", limit=10))
+    assert len(features) == 10
+
+
+def test_get_ids_for_biotype_seqid(yeast_db, yeast):
+    stable_ids = list(
+        yeast_db.get_ids_for_biotype(biotype="protein_coding", seqid="III"),
+    )
+    assert len(stable_ids) == 184  # from direct inspection of sql count distinct
+    stable_ids = list(
+        yeast_db.get_ids_for_biotype(biotype="protein_coding", seqid=["III", "XVI"]),
+    )
+    assert len(stable_ids) == 184 + 511  # from direct inspection of sql count distinct
+    # make sure the seqid match the input
+    seqids = {"III", "XVI"}
+    got = {
+        r.seqid for stable_id in stable_ids for r in yeast.get_features(name=stable_id)
+    }
+    assert got == seqids

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ensembl_tui import _genome as eti_genome
 
 
@@ -13,7 +11,7 @@ def test_get_gene_segments_limit(yeast_db):
 
 
 def test_get_seq_feature_seq_correct(yeast):
-    seq = yeast.get_seq(seqid="III", start=309069, stop=310155)
+    seq = yeast.seqs["III"][309069:310155]
     raw_seq = str(seq)
     assert raw_seq.startswith("ATGCTTTACCCAGAAAAATTTCA")  # expected from ensembl.org
     assert raw_seq.endswith("ATAAGAAATTCCATAAATAG")
@@ -22,7 +20,7 @@ def test_get_seq_feature_seq_correct(yeast):
 def test_get_seq_feature_seq_correct_name(yeast):
     # need to modify cogent3 so it applies the feature name
     # to the new sequence
-    seq = yeast.get_seq(seqid="III", start=309069, stop=310155)
+    seq = yeast.seqs["III"][309069:310155]
     got = next(iter(seq.get_features()))
     feat_seq = got.get_slice()
     assert feat_seq.name == "YCR105W"
@@ -62,39 +60,14 @@ def test_genome_coord_names(yeast_db):
     assert counts.shape[0] == 17
 
 
-def test_empty_hdf5_genome_coord_names(yeast_seqs):
-    assert yeast_seqs.get_coord_names()
-    assert "III" in yeast_seqs.get_coord_names()
-
-
-def test_get_seq(yeast_seqs):
-    mt = yeast_seqs.get_seq_str(seqid="Mito")
+def test_get_seq(yeast):
+    mt = yeast.seqs["Mito"]
     assert len(mt) == 85779  # number for ensembl.org
 
 
-def test_pickling_round_trip(yeast_seqs):
-    import pickle  # nosec B403
-
-    ro = yeast_seqs
-    kwargs = {"seqid": "Mito", "start": 200, "stop": 220}
-    small_seq = yeast_seqs.get_seq_str(**kwargs)
-    # expected value from one run
-    assert small_seq == "AAAGATAAAAAAAATAATGT"
-
-    unpkl = pickle.loads(pickle.dumps(ro))  # nosec B301  # noqa: S301
-    got = unpkl.get_seq_str(**kwargs)
-    assert got == small_seq
-
-
-def test_species_setting(yeast_seqs):
+def test_species_setting(yeast):
     # note that species are converted into the Ensembl db prefix
-    assert yeast_seqs.species == "saccharomyces_cerevisiae"
-    with pytest.raises(ValueError):  # noqa: PT011
-        _ = eti_genome.SeqsDataHdf5(mode="r", source=yeast_seqs.source, species="cat")
-
-
-def test_hash_of_seqs_data(yeast_seqs):
-    assert hash(yeast_seqs) == id(yeast_seqs)
+    assert yeast.info.species == "saccharomyces_cerevisiae"
 
 
 def test_gene_description(worm_db):
@@ -178,26 +151,6 @@ def test_get_gene_segments_stableids(worm_db):
 def test_get_features(yeast):
     features = list(yeast.get_features(biotype="rRNA", limit=10))
     assert len(features) == 10
-
-
-def test_get_ids_for_biotype(yeast):
-    features = list(yeast.get_ids_for_biotype(biotype="rRNA", limit=10))
-    assert len(features) == 10
-
-
-def test_get_ids_for_biotype_seqid(yeast):
-    stable_ids = list(yeast.get_ids_for_biotype(biotype="protein_coding", seqid="III"))
-    assert len(stable_ids) == 184  # from direct inspection of sql count distinct
-    stable_ids = list(
-        yeast.get_ids_for_biotype(biotype="protein_coding", seqid=["III", "XVI"]),
-    )
-    assert len(stable_ids) == 184 + 511  # from direct inspection of sql count distinct
-    # make sure the seqid match the input
-    seqids = {"III", "XVI"}
-    got = {
-        r.seqid for stable_id in stable_ids for r in yeast.get_features(name=stable_id)
-    }
-    assert got == seqids
 
 
 def test_get_celegans_cds(worm):

--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -9,7 +9,7 @@ def test_load_genome(small_install_path):
     config = eti_config.read_installed_cfg(small_install_path)
     species = "caenorhabditis_elegans"
     genome = eti_genome.load_genome(config=config, species=species)
-    assert genome.species == species
+    assert genome.info.species == species
     # directly interrogate the gene view
     stable_id = "WBGene00004893"
     gene = list(


### PR DESCRIPTION
We now rely on the cogent3-h5seqs plugin for storage, so we have replaced
all classes related to Genome with the cogent3 new type
SequenceCollection.

## Summary by Sourcery

Refactor genome storage to leverage the cogent3-h5seqs plugin and cogent3 SequenceCollection, removing all custom HDF5 wrappers and simplifying genome loading, sequence slicing, and annotation APIs.

New Features:
- Add get_ids_for_biotype method to the Annotations API for fetching gene IDs by biotype.

Enhancements:
- Migrate unaligned sequence storage to cogent3_h5seqs’s make_unaligned and load_seqs_data_unaligned functions.
- Replace custom SeqsDataHdf5, Hdf5Mixin, Genome wrapper, and str2arr/arr2str apps with cogent3 SequenceCollection slicing and annotation_db integration.
- Simplify load_genome to return a cogent3 SequenceCollection with attached annotation_db and species info.
- Update CLI and alignment modules to use new SequenceCollection slicing interface and annotation_db.get_ids_for_biotype.
- Remove legacy install_parquet_tables function and storage mixin code throughout ingest and storage modules.

Build:
- Update pyproject.toml to depend on cogent3 and cogent3-h5seqs instead of custom h5py/hdf5plugin and git-pinned cogent3.

CI:
- Bump test data cache key version in GitHub Actions workflow.

Tests:
- Refactor tests to use SequenceCollection slicing (genome.seqs[…]) and info.species instead of custom get_seq and SeqsDataHdf5.
- Add tests covering the newly exposed get_ids_for_biotype annotation method.