### PR TITLE
DEV: add the script for reducing genome sequences size for testing purposes

### DIFF
--- a/tests/data/prep_tests_data/drop_chroms.py
+++ b/tests/data/prep_tests_data/drop_chroms.py
@@ -1,0 +1,32 @@
+import pathlib
+
+import click
+import cogent3
+
+from ensembl_tui import _config as eti_config
+from ensembl_tui import _genome as eti_genome
+
+
+@click.command()
+@click.argument("install_dir", type=pathlib.Path)
+@click.option("--check", is_flag=True)
+def main(install_dir, check):
+    seqid = "22"
+    cfg = eti_config.read_installed_cfg(install_dir)
+
+    for db in cfg.list_genomes():
+        genome_dir = cfg.installed_genome(db)
+
+        src = genome_dir / eti_genome.SEQ_STORE_NAME
+        seqs = cogent3.load_unaligned_seqs(src, moltype="dna", new_type=True)
+        if check:
+            print(f"{db=}  {seqs.names}")
+            continue
+        dest = src.with_suffix(f"{src.suffix}-temp")
+        seqs = seqs.take_seqs([seqid])
+        seqs.write(dest)
+        dest.rename(str(dest).replace("-temp", ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI script to prepare smaller genome sequence files for testing by extracting only chromosome 22 from installed genome data.

New Features:
- Introduce drop_chroms.py as a new utility under tests/data/prep_tests_data to filter genome sequence stores to a single chromosome for faster tests.
- Include a --check flag in the script to preview available sequence IDs without modifying files.