### PR TITLE
DEV: maintenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,99 +110,6 @@ norecursedirs = ["doc", ".nox", "working"]
 addopts = ["--strict-config"]
 testpaths = "tests"
 
-[tool.uv]
-reinstall-package = ["cogent3"]
-
-[tool.ruff]
-exclude = [
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "build",
-    "dist",
-    "site-packages",
-    "venv",
-]
-
-# Same as Black.
-line-length = 88
-indent-width = 4
-
-target-version = "py310"
-
-[tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
-select = ["ALL"]
-# ignoring checks on having boolean flag as arguments to functions
-# ignoring checks on the number of arguments to a functions
-# numpy should NOT always be imported as np
-# turning of SQL injectiuon risk warnings, we are querying public data only
-# turning off checking using open instead of pathlib.Path.open
-ignore = ["EXE002", "FA100", "E501", "D", "ICN001", "FBT001", "FBT002",
-          "PLR0913", "S608", "PTH123"]
-
-# Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [
-    "S101", # asserts allowed in tests...
-    "INP001", # __init__.py files are not required...
-    "ANN",
-    "N802",
-    "N803"
-]
-"noxfile.py" = [
-    "S101", # asserts allowed in tests...
-    "INP001", # __init__.py files are not required...
-    "ANN",
-    "N802",
-    "N803"
-]
-
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
-
-# Like Black, automatically detect the appropriate line ending.
-line-ending = "lf"
-docstring-code-format = true
-
-# Set the line length limit used when formatting code snippets in
-# docstrings.
-#
-# This only has an effect when the `docstring-code-format` setting is
-# enabled.
-docstring-code-line-length = "dynamic"
-
 [tool.scriv]
 format="md"
 categories=["Contributors", "ENH", "BUG", "DOC", "Deprecations", "Discontinued"]
@@ -211,3 +118,6 @@ version="literal: src/ensembl_tui/__init__.py:__version__"
 skip_fragments="README.*"
 new_fragment_template="file: changelog.d/templates/new.md.j2"
 entry_title_template="file: changelog.d/templates/title.md.j2"
+
+[tool.uv]
+reinstall-package = ["cogent3"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,97 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "working",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+target-version = "py310"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["ALL"]
+# ignoring checks on having boolean flag as arguments to functions
+# ignoring checks on the number of arguments to a functions
+# numpy should NOT always be imported as np
+# turning of SQL injectiuon risk warnings, we are querying public data only
+# turning off checking using open instead of pathlib.Path.open
+ignore = ["EXE002", "FA100", "E501", "D", "ICN001", "FBT001", "FBT002",
+          "PLR0913", "S608", "PTH123"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.per-file-ignores]
+"tests/**/*.py" = [
+    "S101", # asserts allowed in tests...
+    "INP001", # __init__.py files are not required...
+    "ANN",
+    "N802",
+    "N803",
+    "S608",  # sql injection unlikely
+]
+"noxfile.py" = [
+    "S101", # asserts allowed in tests...
+    "INP001", # __init__.py files are not required...
+    "ANN",
+    "N802",
+    "N803"
+]
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "lf"
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"
+
+[lint.isort]
+# group ensembl_tui imports last
+known-first-party = ["ensembl_tui"]


### PR DESCRIPTION
## Summary by Sourcery

Externalize Ruff linter and formatter settings into a dedicated ruff.toml and streamline pyproject.toml by removing the embedded tool.ruff configuration while preserving the tool.uv entry.

Enhancements:
- Remove inline Ruff configuration from pyproject.toml to declutter project metadata
- Introduce a standalone ruff.toml file containing all linting, formatting, and per-file ignore rules
- Reposition the tool.uv reinstall-package setting within pyproject.toml for consistency