### PR TITLE
MAINT: new type sequence collections .source attribute should be used

### DIFF
--- a/src/ensembl_tui/__init__.py
+++ b/src/ensembl_tui/__init__.py
@@ -1,10 +1,11 @@
 """Ensembl terminal user interface tools"""
 
+import os
 from warnings import filterwarnings
 
 filterwarnings("ignore", message=".*MPI")
 filterwarnings("ignore", message="Can't drop database.*")
 filterwarnings("ignore", message="A worker stopped while some jobs.*")
 
-
+os.environ["COGENT3_NEW_TYPE"] = "1"
 __version__ = "0.2.1"

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -448,7 +448,7 @@ def homologs(
                 continue
 
             txt = seqs.to_fasta()
-            out_dstore.write(data=txt, unique_id=seqs.info.source)
+            out_dstore.write(data=txt, unique_id=seqs.source)
 
     log_file_path = pathlib.Path(LOGGER.log_file_path)
     LOGGER.shutdown()


### PR DESCRIPTION
[CHANGED] added top level environment statement to turn on new types
    systematically

[CHANGED] use the .source attribute as no longer putting source info into
    the .info dict

## Summary by Sourcery

Enable the new type system by default and update sequence source handling in the CLI

Enhancements:
- Set the COGENT3_NEW_TYPE environment variable to ‘1’ at package initialization to activate new types
- Use the .source attribute instead of seqs.info.source when writing sequence data in the CLI