### PR TITLE
MAINT: change name of cli config export func to demo_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ Some commands can be run in parallel but have moderate memory requirements. If y
 <details>
   <summary>Specifying what data you want to download and where to put it</summary>
 
-  We use a plain text file to indicate the Ensembl domain, release and types of genomic data to download. Start by using the `exportrc` subcommand.
+  We use a plain text file to indicate the Ensembl domain, release and types of genomic data to download. Start by using the `demo-config` subcommand.
 
   <!-- [[[cog
   import cog
   from ensembl_tui import cli
   from click.testing import CliRunner
   runner = CliRunner()
-  result = runner.invoke(cli.main, ["exportrc", "--help"])
+  result = runner.invoke(cli.main, ["demo-config", "--help"])
   help = result.output.replace("Usage: main", "Usage: eti")
   cog.out(
       "```\n{}\n```".format(help)
   )
   ]]] -->
   ```
-  Usage: eti exportrc [OPTIONS]
+  Usage: eti demo-config [OPTIONS]
 
     exports sample config and species table to the nominated path
 
@@ -74,7 +74,7 @@ Some commands can be run in parallel but have moderate memory requirements. If y
   <!-- [[[end]]] -->
 
   ```shell
-  $ eti exportrc -o ~/Desktop/Outbox/ensembl_download
+  $ eti demo-config -o ~/Desktop/Outbox/ensembl_download
   ```
   This command creates a `ensembl_download` download directory and writes two plain text files into it:
 
@@ -234,7 +234,7 @@ We provide a conventional command line interface for querying the data with subc
 
   Commands:
     tui              Open Textual TUI.
-    exportrc         exports sample config and species table to the nominated...
+    demo-config      exports sample config and species table to the nominated...
     download         download data from Ensembl's ftp site
     install          create the local representations of the data
     installed        show what is installed

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -47,7 +47,7 @@ def main() -> None:
 
 @main.command(**_click_command_opts)
 @cli_opt.dbrc_out
-def exportrc(outpath: pathlib.Path) -> None:
+def demo_config(outpath: pathlib.Path) -> None:
     """exports sample config and species table to the nominated path"""
 
     outpath = outpath.expanduser()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_download(tmp_config):
     assert r.exit_code == 0, r.output
     # make sure the download checkpoint file exists
     genome_dir = tmp_dir / "staging" / "genomes"
-    dirnames = [dn for dn in genome_dir.iterdir() if dn.is_dir()]
+    dirnames = [dn.name for dn in genome_dir.iterdir() if dn.is_dir()]
     assert "saccharomyces_cerevisiae" in dirnames
 
     # make sure file sizes > 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 import cogent3
@@ -24,7 +23,7 @@ def test_download(tmp_config):
     assert r.exit_code == 0, r.output
     # make sure the download checkpoint file exists
     genome_dir = tmp_dir / "staging" / "genomes"
-    dirnames = [dn for dn in os.listdir(genome_dir) if (genome_dir / dn).is_dir()]
+    dirnames = [dn for dn in genome_dir.iterdir() if dn.is_dir()]
     assert "saccharomyces_cerevisiae" in dirnames
 
     # make sure file sizes > 0
@@ -41,12 +40,12 @@ def test_download_no_config():
     assert "No config" in r.output
 
 
-def test_exportrc(tmp_dir):
+def test_demo_config(tmp_dir):
     """demo_config works correctly"""
     outdir = tmp_dir / "exported"
     r = RUNNER.invoke(eti_cli.demo_config, [f"-o{outdir}"])
     assert r.exit_code == 0, r.output
-    fnames = os.listdir(outdir)
+    fnames = {f.name for f in outdir.iterdir()}
     assert "species.tsv" in fnames
     assert len(fnames) == 2
     shutil.rmtree(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,9 @@ def test_download_no_config():
 
 
 def test_exportrc(tmp_dir):
-    """exportrc works correctly"""
+    """demo_config works correctly"""
     outdir = tmp_dir / "exported"
-    r = RUNNER.invoke(eti_cli.exportrc, [f"-o{outdir}"])
+    r = RUNNER.invoke(eti_cli.demo_config, [f"-o{outdir}"])
     assert r.exit_code == 0, r.output
     fnames = os.listdir(outdir)
     assert "species.tsv" in fnames


### PR DESCRIPTION
## Summary by Sourcery

Rename the `exportrc` subcommand to `demo_config` (`demo-config`) and update all references in code, documentation, and tests.

Enhancements:
- Rename CLI function and command from exportrc to demo_config/demo-config

Documentation:
- Update README examples and command listing to use demo-config

Tests:
- Update test_cli to rename test_exportrc to test_demo_config and invoke demo_config