### PR TITLE
MAINT: update to latest cogent3 2025.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = ["blosc2",
         "click",
-        # following needs to be replaced by cogent3>=version when
-        # cogent3 annotation db API changes are released
-        "cogent3",
+        "cogent3>=2025.7.10a1",
         "cogent3-h5seqs",
         "duckdb",
         "numba",
@@ -67,26 +65,14 @@ test = [
     "pytest-xdist",
     "ruff==0.10.0",
     "nox"]
-doc  = ["click",
-        "sphinx",
-        "sphinx-autobuild",
-        "sphinx_book_theme",
-        "sphinx_design",
-        "sphinxcontrib-bibtex",
-        "ipykernel",
-        "ipython",
-        "ipywidgets",
-        "jupyter-sphinx",
-        "jupyter_client",
-        "jupyterlab",
-        "jupytext",
-        "kaleido",
-        "nbconvert>5.4",
-        "nbformat",
-        "nbsphinx",
-        "pillow",
-        "plotly",
-        ]
+doc  = [
+    "ensembl-tui",
+    "diverse_seq[extra]",
+    "mkdocs>=1.6.1",
+    "markdown-exec[ansi]>=1.10.0",
+    "mkdocs-jupyter>=0.25.1",
+    "markdown>=3.7",
+]
 dev = ["click",
        "cogapp",
        "flit",

--- a/src/ensembl_tui/__init__.py
+++ b/src/ensembl_tui/__init__.py
@@ -1,11 +1,9 @@
 """Ensembl terminal user interface tools"""
 
-import os
 from warnings import filterwarnings
 
 filterwarnings("ignore", message=".*MPI")
 filterwarnings("ignore", message="Can't drop database.*")
 filterwarnings("ignore", message="A worker stopped while some jobs.*")
 
-os.environ["COGENT3_NEW_TYPE"] = "1"
 __version__ = "0.2.1"

--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -6,7 +6,7 @@ import cogent3
 import numpy
 import typing_extensions
 from cogent3.app.composable import define_app
-from cogent3.core import new_alignment as c3_align
+from cogent3.core import alignment as c3_align
 from cogent3.core.location import _DEFAULT_GAP_DTYPE, IndelMap
 
 from ensembl_tui import _annotation as eti_ann
@@ -14,7 +14,7 @@ from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
 
-DNA = cogent3.get_moltype("dna", new_type=True)
+DNA = cogent3.get_moltype("dna")
 
 _no_gaps = numpy.array([], dtype=_DEFAULT_GAP_DTYPE)
 

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -8,8 +8,8 @@ import cogent3
 import cogent3_h5seqs as c3h5
 import numpy
 from cogent3.app.composable import define_app
-from cogent3.core import new_alphabet
-from cogent3.core.new_sequence import Sequence
+from cogent3.core import alphabet as c3alpha
+from cogent3.core.sequence import Sequence
 from cogent3.core.table import Table
 from cogent3.parse.fasta import iter_fasta_records
 
@@ -20,9 +20,9 @@ from ensembl_tui import _util as eti_util
 
 SEQ_STORE_NAME = f"genome-seqs.{c3h5.UNALIGNED_SUFFIX}"
 
-DNA = cogent3.get_moltype("dna", new_type=True)
+DNA = cogent3.get_moltype("dna")
 alphabet = DNA.most_degen_alphabet()  # type: ignore  # noqa: PGH003
-bytes_to_array = new_alphabet.bytes_to_array(
+bytes_to_array = c3alpha.bytes_to_array(
     chars=alphabet.as_bytes(),
     dtype=numpy.uint8,
     delete=b" \n\r\t",
@@ -51,7 +51,7 @@ class fasta_to_hdf5:  # noqa: N801
         # we directly use the cogent3_h5seqs library to create the
         # unaligned hdf5 file. This library is valid storage for
         # cogent3 collections
-        alpha = cogent3.get_moltype("dna", new_type=True).most_degen_alphabet()
+        alpha = cogent3.get_moltype("dna").most_degen_alphabet()
         seq_store = c3h5.make_unaligned(out_path, alphabet=alpha, mode="w")
         seq_store.set_attr(
             "species",
@@ -100,14 +100,13 @@ def load_genome(*, config: eti_config.InstalledConfig, species: str):
     """returns the genome with annotations"""
     genome_path = config.installed_genome(species) / SEQ_STORE_NAME
     storage = c3h5.load_seqs_data_unaligned(genome_path)
-    dna = cogent3.get_moltype("dna", new_type=True)
+    dna = cogent3.get_moltype("dna")
     ann = eti_annots.Annotations(source=config.installed_genome(species))
     return cogent3.make_unaligned_seqs(
         storage,
         moltype=dna,
         annotation_db=ann,
         info={"species": species},
-        new_type=True,
     )
 
 

--- a/src/ensembl_tui/_homology.py
+++ b/src/ensembl_tui/_homology.py
@@ -240,8 +240,7 @@ class collect_cds:
             )
 
         return make_unaligned_seqs(
-            data=seqs,
+            seqs,
             moltype="dna",
-            info={"source": homologs.source},
-            new_type=True,
+            source=homologs.source,
         )

--- a/src/ensembl_tui/_ingest_align.py
+++ b/src/ensembl_tui/_ingest_align.py
@@ -18,7 +18,7 @@ _no_gaps = numpy.array([], dtype=numpy.int32)
 
 
 def seq2gaps(record: dict) -> eti_align.AlignRecord:
-    seq = make_seq(record.pop("seq").upper(), new_type=True, moltype="dna")
+    seq = make_seq(record.pop("seq").upper(), moltype="dna")
     indel_map, _ = seq.parse_out_gaps()
     if indel_map.num_gaps:
         record["gap_spans"] = numpy.array(

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -51,8 +51,10 @@ def demo_config(outpath: pathlib.Path) -> None:
     """exports sample config and species table to the nominated path"""
 
     outpath = outpath.expanduser()
-
-    shutil.copytree(eti_util.ENSEMBLDBRC, outpath)
+    if outpath.exists():
+        shutil.rmtree(outpath)
+    outpath.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(eti_util.ENSEMBLDBRC, outpath, dirs_exist_ok=True)
     # we assume all files starting with alphabetical characters are valid
     for fn in pathlib.Path(outpath).glob("*"):
         if not fn.stem.isalpha():
@@ -112,11 +114,11 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
             progress.TaskProgressColumn(),
             progress.TimeRemainingColumn(),
             progress.TimeElapsedColumn(),
-        ) as progress,
+        ) as prog_bar,
     ):
-        eti_download.download_species(config, debug, verbose, progress=progress)
-        eti_download.download_homology(config, debug, verbose, progress=progress)
-        eti_download.download_aligns(config, debug, verbose, progress=progress)
+        eti_download.download_species(config, debug, verbose, progress=prog_bar)
+        eti_download.download_homology(config, debug, verbose, progress=prog_bar)
+        eti_download.download_aligns(config, debug, verbose, progress=prog_bar)
 
     eti_util.print_colour(text=f"Downloaded to {config.staging_path}", colour="green")
 
@@ -159,28 +161,28 @@ def install(
             progress.TaskProgressColumn(),
             progress.TimeRemainingColumn(),
             progress.TimeElapsedColumn(),
-        ) as progress,
+        ) as progress_bar,
     ):
         local_install_genomes(
             config,
             force_overwrite=force_overwrite,
             max_workers=num_procs,
             verbose=verbose,
-            progress=progress,
+            progress=progress_bar,
         )
         local_install_homology(
             config,
             force_overwrite=force_overwrite,
             max_workers=num_procs,
             verbose=verbose,
-            progress=progress,
+            progress=progress_bar,
         )
         local_install_alignments(
             config,
             force_overwrite=force_overwrite,
             max_workers=num_procs,
             verbose=verbose,
-            progress=progress,
+            progress=progress_bar,
         )
 
     eti_util.print_colour(
@@ -401,20 +403,20 @@ def homologs(
         progress.TaskProgressColumn(),
         progress.TimeRemainingColumn(),
         progress.TimeElapsedColumn(),
-    ) as progress:
-        searching = progress.add_task(
+    ) as progress_bar:
+        searching = progress_bar.add_task(
             total=limit or len(ref_genes),
             description="Homolog search",
         )
         for gid in ref_genes:
             if rel := db.get_related_to(gene_id=gid, relationship_type=homology_type):
                 related.append(rel)
-                progress.update(searching, advance=1)
+                progress_bar.update(searching, advance=1)
 
             if limit and len(related) >= limit:
                 break
 
-        progress.update(searching, advance=len(ref_genes))
+        progress_bar.update(searching, advance=len(ref_genes))
 
         if verbose:
             eti_util.print_colour(
@@ -425,14 +427,14 @@ def homologs(
         get_seqs = eti_homology.collect_cds(config=config)
         out_dstore = open_data_store(base_path=outdir, suffix="fa", mode="w")
 
-        reading = progress.add_task(total=len(related), description="Extracting 🧬")
+        reading = progress_bar.add_task(total=len(related), description="Extracting 🧬")
         for seqs in get_seqs.as_completed(
             related,
             parallel=num_procs > 1,
             show_progress=False,
             par_kw={"max_workers": num_procs},
         ):
-            progress.update(reading, advance=1)
+            progress_bar.update(reading, advance=1)
             if not seqs:
                 if verbose:
                     eti_util.print_colour(text=f"{seqs=}", colour="yellow")
@@ -477,8 +479,8 @@ def alignments(
     ref: str,
     coord_names: str,
     ref_genes: list[str] | None,
-    mask: pathlib.Path,
-    mask_shadow: pathlib.Path,
+    mask: list[str] | None,
+    mask_shadow: list[str] | None,
     mask_ref: bool,
     ref_coords: list[eti_genome.genome_segment],
     limit: int,
@@ -591,7 +593,7 @@ def alignments(
         mask_ref=mask_ref,
     )
     output = open_data_store(outdir, mode="w", suffix="fa")
-    writer = get_app("write_seqs", format="fasta", data_store=output)
+    writer = get_app("write_seqs", format_name="fasta", data_store=output)
     with (
         eti_util.keep_running(),
         progress.Progress(
@@ -600,14 +602,14 @@ def alignments(
             progress.TaskProgressColumn(),
             progress.TimeRemainingColumn(),
             progress.TimeElapsedColumn(),
-        ) as progress,
+        ) as progress_bar,
     ):
-        task = progress.add_task(
+        task = progress_bar.add_task(
             total=limit or len(locations),
             description="Getting alignment data",
         )
         for alignments in maker.as_completed(locations, show_progress=False):
-            progress.update(task, advance=1)
+            progress_bar.update(task, advance=1)
             if not alignments:
                 eti_util.print_colour(str(alignments), colour="red")
                 continue

--- a/src/ensembl_tui/data/sample.cfg
+++ b/src/ensembl_tui/data/sample.cfg
@@ -7,11 +7,11 @@ path=pub
 # and where the installation will be placed.
 # The paths can be absolute (begin with /), as in this case,
 # or relative to the location of this cfg file (begin with ./).
-staging_path=ensembl_download_112
-install_path=ensembl_install_112
+staging_path=ensembl_download_114
+install_path=ensembl_install_114
 [release]
 # The release of Ensembl that you want to sample data from.
-release=112
+release=114
 [Saccharomyces cerevisiae]
 # You specify the species that you want to be downloaded by including the 
 # Latin or common name (as defined by Ensembl) within the square brackets.

--- a/tests/data/prep_tests_data/prep_ape_test.py
+++ b/tests/data/prep_tests_data/prep_ape_test.py
@@ -66,7 +66,7 @@ def drop_annotations(genome_dir: pathlib.Path, seqid: str = "22"):
 
 def drop_chrom(genome_dir: pathlib.Path, seqid: str = "22", check: bool = True):
     src = genome_dir / eti_genome.SEQ_STORE_NAME
-    seqs = cogent3.load_unaligned_seqs(src, moltype="dna", new_type=True)
+    seqs = cogent3.load_unaligned_seqs(src, moltype="dna")
     if check:
         print(f"{genome_dir.name=}  {seqs.names}")
         return

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -91,11 +91,9 @@ def small_seqs():
         "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
     }
     return make_aligned_seqs(
-        data=seqs,
+        seqs,
         moltype="dna",
-        array_align=False,
         info={"species": {"s1": "human", "s2": "mouse", "s3": "dog"}},
-        new_type=True,
     )
 
 
@@ -180,7 +178,6 @@ def genomedbs_aligndb(small_records):
             genome,
             annotation_db=None,
             info={"species": species[name]},
-            new_type=True,
             moltype="dna",
         )
 
@@ -242,7 +239,6 @@ def make_sample(two_aligns=False):
             genome,
             annotation_db=annot_dbs[name],
             info={"species": species[name]},
-            new_type=True,
             moltype="dna",
         )
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -11,7 +11,7 @@ def test_get_db_names(tmp_config):
     cfg = eti_config.read_config(tmp_config)
     db_names = eti_download.get_core_db_dirnames(cfg)
     assert db_names == {
-        "saccharomyces_cerevisiae": "pub/release-112/mysql/saccharomyces_cerevisiae_core_112_4",
+        "saccharomyces_cerevisiae": "pub/release-114/mysql/saccharomyces_cerevisiae_core_114_4",
     }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Upgrade project to use the latest cogent3 2025.7 API, adjust code, tests, and dependencies accordingly, and update documentation dependencies and sample configuration for Ensembl release 114.

Enhancements:
- Adapt code to remove deprecated new_type usage and align with updated cogent3 API for get_moltype, make_seq, and sequence storage operations
- Standardize progress bar variable names in CLI commands and enhance demo_config to remove existing output paths before copying
- Update sample.cfg to reference Ensembl release 114 paths

Build:
- Bump cogent3 dependency to >=2025.7.10a1

Documentation:
- Replace Sphinx-based doc dependencies with mkdocs, markdown-exec, and mkdocs-jupyter tooling in pyproject.toml

Tests:
- Remove new_type arguments from sequence and alignment tests and update expected download paths to release 114