### PR TITLE
Misc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13.3"]
+        python-version: ["3.10", "3.13"]
 
     steps:
       - uses: "actions/checkout@v4"

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -47,10 +47,19 @@ def main() -> None:
 
 @main.command(**_click_command_opts)
 @cli_opt.dbrc_out
-def demo_config(outpath: pathlib.Path) -> None:
+@cli_opt.force
+def demo_config(outpath: pathlib.Path, force_overwrite: bool) -> None:
     """exports sample config and species table to the nominated path"""
 
     outpath = outpath.expanduser()
+    if outpath.exists() and not force_overwrite:
+        eti_util.print_colour(
+            text=f"{outpath} exists, use --force_overwrite to overwrite",
+            colour="blue",
+            style="bold",
+        )
+        sys.exit(1)
+
     if outpath.exists():
         shutil.rmtree(outpath)
     outpath.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,15 @@ def test_demo_config(tmp_dir):
     shutil.rmtree(tmp_dir)
 
 
+def test_demo_config_exists(tmp_dir):
+    outdir = tmp_dir / "exported"
+    outdir.mkdir(parents=True, exist_ok=True)
+    r = RUNNER.invoke(eti_cli.demo_config, [f"-o{outdir}"])
+    assert r.exit_code == 1
+    r = RUNNER.invoke(eti_cli.demo_config, [f"-o{outdir}", "--force_overwrite"])
+    assert r.exit_code == 0
+
+
 @pytest.fixture(scope="module")
 def installed(tmp_downloaded):
     # tmp_downloaded is a temp copy of the download folder


### PR DESCRIPTION
## Summary by Sourcery

Introduce a force-overwrite option to the demo_config CLI command to prevent accidental overwrites, add tests for this behavior, and update GitHub Actions workflows to support Python 3.13.

New Features:
- Add --force_overwrite flag to demo_config command to enable explicit overwriting of existing directories

Enhancements:
- Make demo_config exit with a warning and non-zero code when the output path exists without --force_overwrite

CI:
- Update release workflow matrix to include Python 3.13
- Adjust testing_develop workflow to run on Python 3.10 and 3.13

Tests:
- Add tests to verify demo_config fails on existing paths without force and succeeds with --force_overwrite