### PR TITLE
DOC: setting up automated doc building

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,87 @@
+name: Build Docs
+
+concurrency:
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.readthedocs.yaml'
+      - 'mkdocs.yml'
+      - 'rtd_get_docs.py'
+
+permissions:
+  contents: read
+
+jobs:          
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+                - name: Set up small cache
+        id: cache-small-data
+        uses: actions/cache@v3
+        with:
+          path: docs/data
+          key: ${{ runner.os }}-small-v1-${{ hashFiles('docs/data/small-114.zip') }}
+          restore-keys: |
+            ${{ runner.os }}-small-v1-
+
+      - name: Check cache status
+        run: |
+          echo "Cache hit: ${{ steps.cache-data.outputs.cache-hit }} ***"
+
+      - name: Download small data file
+        if: steps.cache-data.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o docs/data/small-114.zip "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+
+      - name: Set up apes cache
+        id: cache-apes-data
+        uses: actions/cache@v3
+        with:
+          path: docs/data
+          key: ${{ runner.os }}-apes-v1-${{ hashFiles('docs/data/apes-114.zip') }}
+          restore-keys: |
+            ${{ runner.os }}-apes-v1-
+
+      - name: Check cache status
+        run: |
+          echo "Cache hit: ${{ steps.cache-data.outputs.cache-hit }} ***"
+
+      - name: Download apes data file
+        if: steps.cache-data.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o docs/data/apes-114.zip "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install Docs Dependencies
+        run: |
+          uv venv venv -p python${{ matrix.python-version }}
+          uv pip install -p .[doc]
+
+      - name: Build Documentation
+        run: |
+          source venv/bin/activate
+          mkdocs build
+        working-directory: ${{ github.workspace }}
+
+      - name: Upload Documentation Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ensembl_tui-docs-html
+          path: site

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:          
   build-docs:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-                - name: Set up small cache
+      - name: Set up small cache
         id: cache-small-data
         uses: actions/cache@v3
         with:
@@ -63,6 +64,10 @@ jobs:
         run: |
           curl -L -o docs/data/apes-114.zip "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
 
+      - uses: "actions/setup-python@v5"
+        with:
+            python-version: "3.13"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -71,8 +76,9 @@ jobs:
 
       - name: Install Docs Dependencies
         run: |
-          uv venv venv -p python${{ matrix.python-version }}
-          uv pip install -p .[doc]
+          uv venv venv -p python
+          source venv/bin/activate
+          uv pip install ".[doc]"
 
       - name: Build Documentation
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  commands:
+    # Install the required dependencies
+    - pip install requests
+    # Run the script to download and extract the pre-built docs
+    - python rtd_get_docs.py
+    - echo "Documentation downloaded and extracted"
+
+# Disable the default build processes since we're using pre-built docs
+sphinx:
+  configuration: null
+
+python:
+  install: []

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,87 @@
+# Selecting Ensembl Data
+
+`ensembl-tui` requires a config file to specify the data that you want to select from Ensembl.
+
+```bash exec="1"
+mkdir -p demo # markdown-exec: hide
+```
+
+## Create a template config file to edit
+
+`eti` can write a template config file to a directory you specify.
+
+```console exec="1" source="console" result="ansi" workdir="./demo"
+$ eti demo-config --outpath example
+```
+
+The config template file is written to the specified directory along with a `species.tsv` file which includes a listing of Ensembl species.
+
+```console exec="1" source="console" result="ansi" workdir="./demo"
+$ ls example/
+```
+
+### The species contents
+
+```console exec="1" source="console" result="ansi" workdir="./demo"
+$ head -n 5 example/species.tsv
+```
+### The config contents
+
+```console exec="1" source="console" result="ansi" workdir="./demo"
+$ head -n 15 example/sample.cfg
+```
+
+## The config format
+
+This is a `.ini` format. A section is denoted by square brackets surrounding the section name, e.g. `[remote path]`. Variables within a section are denoted by the name followed by an `=`.
+
+### `[remote path]`
+
+This is the section defining which Ensembl FTP server hosts the data and the remote path. At present, we are only supporting the primary Ensembl Server, so this section should be left as is.
+
+### `[local path]`
+
+Specify where to download the data to (`staging_path`) on your machine and where to write your installation (`install_path`).
+
+### `[release]`
+
+Specify the ensemble release.
+
+### `[<species name>]`
+
+Selecting a species is done by providing a section with the species name as a section. Available species can be found in the species.tsv file which is written out by the `demo-config` command.
+
+For now, you must include `db=core` under the species section.
+
+### `[compara]`
+
+Sources from the Compara database are indicated here. Including `homologies =` (without a value) indicates that you want to get the homology information for all the selected species.
+
+You can indicate the alignments you want as comma separated values assigned to the variable `align_names`. 
+
+> **Note**
+> To select the alignments that you want, you will need to navigate the Ensembl FTP site for the release you are interested in.
+
+## Implicit selection of genomes
+
+If you specify a whole genome alignment and do not specify any specific species, then all of the species present in that whole genome alignment will be downloaded.
+
+For example, the following config would download 10 primate genomes along with whole genome alignments and homology data.
+
+```ini
+[remote path]
+host=ftp.ensembl.org
+path=pub
+[local path]
+staging_path=download_114
+install_path=install_114
+[release]
+release=114
+[compara]
+align_names=10_primates.epo
+homologies =
+```
+
+```bash exec="1"
+rm -rf demo # markdown-exec: hide
+```

--- a/docs/data/apes.cfg
+++ b/docs/data/apes.cfg
@@ -1,0 +1,17 @@
+[remote path]
+path = pub
+host = ftp.ensembl.org
+[local path]
+staging_path = apes-114-download
+install_path = apes-114
+[release]
+release = 114
+[compara]
+align_names = 10_primates.epo
+homologies =
+[pan_troglodytes]
+db = core
+[homo_sapiens]
+db = core
+[gorilla_gorilla]
+db = core

--- a/docs/data/small.cfg
+++ b/docs/data/small.cfg
@@ -1,0 +1,14 @@
+[remote path]
+host=ftp.ensembl.org
+path=pub
+[local path]
+staging_path=small-114/download
+install_path=small-114/install
+[release]
+release=114
+[Saccharomyces cerevisiae]
+db=core
+[Caenorhabditis elegans]
+db=core
+[compara]
+homologies=

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,12 @@
+# Download data from Ensembl
+
+This command downloads the data from the Ensembl server saving it into `staging_path` as specified in the config file. This is the only step that requires Internet access.
+
+In addition to writing the original files from Ensembl, an expanded version of the config file is also written into the download directory. This is required for the subsequent `install` step.
+
+```
+$ eti download -c example/sample.cfg
+```
+
+> **Note**
+> Downloading takes advantage of multiple threads and can be interrupted and resumed.

--- a/docs/genome.md
+++ b/docs/genome.md
@@ -1,0 +1,37 @@
+# Querying genomes
+
+```bash exec="1"
+mkdir -p demo # markdown-exec: hide
+```
+
+## Summary of this installation
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti installed -i data/apes-114
+```
+> **Note**
+> :material-download: [Download ape data](data/apes-114.zip) (zip, ~45 MB).
+
+## Summary for a species
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti species-summary -i data/apes-114 --species human
+```
+
+## Export gene meta-data for a species
+
+> **Note**
+> The list of data from this query only covers human chromosome 22 because we are using a custom subset of the original Ensembl data.
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti dump-genes -i data/apes-114 --species human -od human_data
+```
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ head human_data/homo_sapiens-114-gene_metadata.tsv
+```
+
+```bash exec="1"
+rm -rf demo # markdown-exec: hide
+rm -rf human_data # markdown-exec: hide
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+`ensembl-tui` provides a textual interface to localised ensembl genomic data.
+
+## Installing the software
+
+`ensembl-tui` can be installed from PyPI as follows
+
+```
+pip install ensembl-tui
+```
+
+> **NOTE**
+> If you experience any errors during installation, we recommend using [uv pip](https://docs.astral.sh/uv/). This command provides much better error messages than the standard `pip` command. If you cannot resolve the installation problem, please [open an issue](https://github.com/cogent3/ensembl_tui/issues).
+
+
+> **Note**
+> The first usage of `ensembl-tui` is slow because both `cogent3` and `ensembl-tui` are compiling some functions. This is a one-time cost.
+
+## Installation and usage with `uv`
+
+Speaking of `uv`, it provides a simplified approach to install `eti` as a command-line only tool as
+
+```
+uv tool install ensembl-tui
+```
+
+For the examples in this documentation, you can access the `eti` command as
+
+```
+uvx --from ensembl-tui eti
+```
+
+without having to activate a virtual environment.
+
+## Getting Help
+
+To see the options for `eti` or one of its subcommands, just enter the expression in the terminal and press return. For example,
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti
+```
+lists all of the subcommands. While
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti download
+```
+shows the options for the download command.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,26 @@
+# Installing Ensembl data
+
+The install step converts the downloaded data into more efficient data structures. These are written to the `install_path` as specified in the config file. 
+
+The install command requires the path to the download directory.
+
+```
+$ eti install -d ensembl_install_114
+```
+
+> **Note**
+> You can utilize multiple processes on your machine for this installation step with the `-np #` argument. We recommend specifying the same number of processes as the number of genomes, e.g. `-np 10` for ten genomes.
+
+## Check your installation
+
+Once you have finished your installation, you can check its contents using the `installed` command.
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti installed -i data/apes-114
+```
+
+> **Note**
+> Here we start specifying the installation directory using the `-i` option. This is required for all commands that reference an installation.
+
+> **Warning**
+> At, present installation is not interruptible. If you need to reinstall, you will need to force overwriting of the current installation using the `--force_overwrite`` argument.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart
+
+Installation of `ensembl-tui` creates a command line tool `eti` which contains a number of subcommands that allow you to acquire and then sample from Ensembl genomic datasets. The general workflow is:
+
+In this quick start, we'll perform the following steps:
+
+1. Create a demo config file
+2. Download raw data from Ensembl
+3. Make the local installation
+4. Show summaries of the installation
+5. Export gene meta-data
+6. Export homology data
+
+## Create a demo config
+
+You specify the genomic resources that you want from Ensembl using a config file. `ensembl-tui` comes with an example file with comments describing what each of the components of that file are.
+
+```
+$ eti demo-config -o demo
+```
+
+> **Note**
+> The config specifies download the genomes and annotations from Ensembl release 114 of  *Saccharomyces cerevisiae* and *Caenorhabditis elegans* and gene homology data. It also specifies the path to write the downloaded files and where to install them.
+
+## Download the specified data
+
+```
+$ eti download -c demo/sample.cfg
+```
+
+> **Note**
+> Downloads can be interrupted.
+
+## Make the local installation
+
+```
+$ eti install -c ensembl_download_114
+```
+
+## Show summaries of the installation
+
+### The top level
+
+```
+$ eti installed -i ensembl_install_114
+```
+
+### Summary of a species
+
+```
+$ eti species-summary -i ensembl_install_114 --species saccharomyces_cerevisiae
+```
+
+### Summary of compara
+
+```
+$ eti compara-summary -i ensembl_install_114
+```
+ This shows the relationships between the species installed.
+
+## Export gene meta-data
+
+```bash exec="1"
+rm -rf worm # markdown-exec: hide
+rm -rf yeast # markdown-exec: hide
+```
+
+```
+$ eti dump-genes -i ensembl_install_114 --species saccharomyces_cerevisiae --outdir yeast
+```
+
+Show the first five lines of the output file.
+
+```
+$ head -n 5 yeast/saccharomyces_cerevisiae*.tsv
+```
+
+## Export homology data
+
+```bash exec="1"
+rm -rf worm_yeast # markdown-exec: hide
+```
+
+```
+$ eti homologs -i ensembl_install_114 --ref caenorhabditis_elegans --outdir worm_yeast --homology_type ortholog_one2one --limit 5
+```
+Listing the files that are written into the specified `worm_yeast` directory.
+
+```
+$ ls worm_yeast
+```

--- a/docs/sample-alignments.md
+++ b/docs/sample-alignments.md
@@ -1,0 +1,7 @@
+# Subsampling whole genome alignments
+
+The alignments function returns whole genome alignments for a given set of coordinates from a reference species.
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti alignments -i data/apes-114 --align_name "*primates*" --outdir apes_aligns --ref human --coord_names 22 --limit 5 --mask "cds,dust"
+```

--- a/docs/sample-homologs.md
+++ b/docs/sample-homologs.md
@@ -1,0 +1,11 @@
+# Selecting homologs
+
+Homologs are related genes and the output is the raw sequence which is unaligned.
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti homologs -i data/apes-114 --outdir apes_homologs --ref human --coord_names 22 --limit 5
+```
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ ls apes_homologs
+```

--- a/docs/scripts/setup_data.py
+++ b/docs/scripts/setup_data.py
@@ -1,0 +1,42 @@
+import pathlib
+import shutil
+import urllib.request
+import zipfile
+
+root_dir = pathlib.Path(__file__)
+while not (root_dir / "data").exists():
+    root_dir = root_dir.parent
+
+DATA_DIR = root_dir / "data"
+
+SMALL_DATA_URL = "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+SMALL_DATA_DIRNAME = "small-114"
+
+APES_DATA_URL = "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
+APES_DATA_DIRNAME = "apes-114"
+
+
+def setup_installed(url: str, dest: str) -> str:
+    zip_dest = DATA_DIR / f"{dest}.zip"
+    expected = DATA_DIR / dest
+    if zip_dest.exists() and expected.exists():
+        shutil.rmtree(expected)
+    elif not zip_dest.exists():
+        urllib.request.urlretrieve(url, filename=zip_dest)  # noqa: S310
+
+    with zipfile.ZipFile(zip_dest, "r") as zip_ref:
+        zip_ref.extractall(DATA_DIR)
+
+    return dest
+
+
+def on_pre_build(*args, **kwargs) -> None:
+    for url, dirname in [
+        (SMALL_DATA_URL, SMALL_DATA_DIRNAME),
+        (APES_DATA_URL, APES_DATA_DIRNAME),
+    ]:
+        setup_installed(url, dirname)
+
+
+if __name__ == "__main__":
+    on_pre_build()

--- a/docs/summary-compara.md
+++ b/docs/summary-compara.md
@@ -1,0 +1,5 @@
+# Querying Compara
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ eti compara-summary -i data/apes-114
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,54 @@
+site_name: ensembl-tui
+site_url: "https://github.com/cogent3/ensembl_tui"
+site_author: "Gavin Huttley"
+repo_url: "https://github.com/cogent3/ensembl_tui"
+repo_name: 'GitHub'
+
+theme:
+    name: material
+    highlightjs: true
+    hljs_languages:
+        - yaml
+        - python
+        - text
+        - bash
+    features:
+        - navigation.sections
+        - toc.follow
+        - toc.integrate
+
+plugins:
+    - mkdocs-jupyter:
+        allow_errors: false
+        remove_tag_config:
+            remove_input_tags:
+              - hide_code
+        include_requirejs: true
+        execute: true
+        ignore:
+            - "scripts/**"
+    - markdown-exec:
+        ansi: required
+
+hooks:
+    - docs/scripts/setup_data.py
+
+markdown_extensions:
+- pymdownx.superfences
+- pymdownx.emoji:
+    emoji_index: !!python/name:material.extensions.emoji.twemoji
+    emoji_generator: !!python/name:material.extensions.emoji.to_svg
+- toc:
+    toc_depth: 3
+
+nav:
+    - Introduction: index.md
+    - Quick Start: quickstart.md
+    - Usage:
+        - config.md
+        - download.md
+        - install.md
+        - genome.md
+        - summary-compara.md
+        - sample-homologs.md
+        - sample-alignments.md


### PR DESCRIPTION
## Summary by Sourcery

Set up automated documentation build pipeline using GitHub Actions and MkDocs, integrate pre-built docs with ReadTheDocs, and add comprehensive documentation content and supporting scripts and configs.

Enhancements:
- Add GitHub Actions workflow to build MkDocs site, cache and download example data, and upload HTML artifact
- Add ReadTheDocs configuration to fetch and deploy pre-built documentation
- Configure MkDocs site settings, theme, plugins, and navigation in mkdocs.yml
- Include Python script to download and extract example data before building docs
- Add example config files under docs/data for demonstration purposes

Documentation:
- Add new documentation pages covering quickstart, configuration guide, download/install usage, genome queries, homology sampling, alignment subsampling, and Compara summary