### PR TITLE
TST: testing alignment annotation handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = ["blosc2",
         "click",
-        "cogent3>=2025.7.10a1",
+        "cogent3>=2025.7.10a3",
         "cogent3-h5seqs",
         "duckdb",
         "numba",

--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -1,4 +1,5 @@
 import dataclasses
+import sys
 import typing
 from collections import defaultdict
 
@@ -10,6 +11,7 @@ from cogent3.core import alignment as c3_align
 from cogent3.core.location import _DEFAULT_GAP_DTYPE, IndelMap
 
 from ensembl_tui import _annotation as eti_ann
+from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _storage_mixin as eti_storage
 from ensembl_tui import _util as eti_util
@@ -400,3 +402,25 @@ class construct_alignment:  # noqa: N801
             results.append(aln)
 
         return results
+
+
+def load_aligndb(config: eti_config.InstalledConfig, align_name: str) -> AlignDb:
+    """returns an AlignDb instance for the given config"""
+    align_name = eti_util.strip_quotes(align_name)
+    align_path = config.path_to_alignment(align_name, ALIGN_STORE_SUFFIX)
+    if align_path is None:
+        eti_util.print_colour(
+            text=f"{align_name!r} does not match any alignments under '{config.aligns_path}'",
+            colour="red",
+        )
+        available = "\n".join(
+            [
+                fn.stem
+                for fn in config.aligns_path.glob("*")
+                if not fn.name.startswith(".") and fn.is_dir()
+            ],
+        )
+        eti_util.print_colour(text=f"Available alignments:\n{available}", colour="red")
+        sys.exit(1)
+
+    return AlignDb(source=align_path)

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -933,7 +933,7 @@ class MultispeciesAnnotations(AnnotationDbABC):
     def __len__(self) -> int:
         return sum(len(ann) for ann in self.species_annotations.values())
 
-    def get_features_matching(self, seqid: str, **kwargs):
+    def get_features_matching(self, *, seqid: str | None = None, **kwargs):
         if seqid not in self.name_map:
             return ()
         sp_sid = self.name_map[seqid]

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -522,24 +522,7 @@ def alignments(
         shutil.rmtree(outdir, ignore_errors=True)
 
     config = eti_config.read_installed_cfg(installed)
-    align_name = eti_util.strip_quotes(align_name)
-    align_path = config.path_to_alignment(align_name, eti_align.ALIGN_STORE_SUFFIX)
-    if align_path is None:
-        eti_util.print_colour(
-            text=f"{align_name!r} does not match any alignments under '{config.aligns_path}'",
-            colour="red",
-        )
-        available = "\n".join(
-            [
-                fn.stem
-                for fn in config.aligns_path.glob("*")
-                if not fn.name.startswith(".") and fn.is_dir()
-            ],
-        )
-        eti_util.print_colour(text=f"Available alignments:\n{available}", colour="red")
-        sys.exit(1)
-
-    align_db = eti_align.AlignDb(source=align_path)
+    align_db = eti_align.load_aligndb(config=config, align_name=align_name)
     ref_species = eti_species.Species.get_ensembl_db_prefix(ref)
     if ref_species not in align_db.get_species_names():
         eti_util.print_colour(
@@ -591,7 +574,6 @@ def alignments(
             limit=limit,
             stableids=stableids,
         )
-
     mask = mask_shadow or mask
     shadow = bool(mask_shadow)
     maker = eti_align.construct_alignment(

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -561,3 +561,32 @@ def test_load_align_records():
     }
     got = eti_ingest_align.seq2gaps(maf_record)
     assert (got.gap_spans == numpy.array([[0, 1]], dtype=numpy.int32)).all()
+
+
+def test_aln_annotation_db_querying(apes_install_path):
+    config = eti_config.read_installed_cfg(apes_install_path)
+    align_db = eti_align.load_aligndb(config=config, align_name="primate")
+    genomes = {
+        sp: eti_genome.load_genome(config=config, species=sp)
+        for sp in align_db.get_species_names()
+    }
+    locus = eti_genome.genome_segment(
+        species="homo_sapiens",
+        seqid="22",
+        start=39504230,
+        stop=39504443,
+        strand=1,
+        unique_id="ENSG00000285025",
+    )
+    maker = eti_align.construct_alignment(
+        align_db=align_db,
+        genomes=genomes,
+        mask_features=None,
+        shadow=None,
+        mask_ref=None,
+    )
+    aln = maker(locus)[0]
+    features = list(
+        aln.get_features(seqid="homo_sapiens:22:39504230-39504443:1", biotype="cds"),
+    )
+    assert features


### PR DESCRIPTION
[CHANGED] put code for loading an alignment db into
    a convenience function to simplify testing

[CHANGED] updated cogent3 minimum version to address
    test failure

## Summary by Sourcery

Centralize alignment database loading with a new load_aligndb helper and refactor the CLI to use it, bump the cogent3 dependency, tighten the get_features_matching signature, and add a test for alignment annotation querying

New Features:
- Introduce load_aligndb helper for consistent alignment database loading

Enhancements:
- Refactor CLI alignments command to use load_aligndb instead of duplicating loading logic
- Require seqid as a keyword-only parameter in get_features_matching

Build:
- Bump cogent3 dependency to >=2025.7.10a3

Tests:
- Add test for querying annotation features from the loaded alignment database