### PR TITLE
DO: modify doc build and docs for alignments

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - develop
     paths:
       - 'docs/**'
       - '.readthedocs.yaml'

--- a/docs/sample-alignments.md
+++ b/docs/sample-alignments.md
@@ -14,5 +14,6 @@ import cogent3
 loader = cogent3.get_app("load_aligned", moltype="dna")
 align_dir = cogent3.open_data_store("apes_aligns", suffix="fa")
 aln = loader(align_dir[1])
-print(aln)
+# pretty print the first 200 bases
+print(aln[:200].to_pretty(wrap=60))
 ```


### PR DESCRIPTION
## Summary by Sourcery

Update documentation example for alignments and adjust docs build workflow to run on the develop branch

CI:
- Modify GitHub Actions docs build to trigger on the develop branch instead of main

Documentation:
- Enhance sample-alignments.md to pretty-print the first 200 bases wrapped at 60 characters