### PR TITLE
DEV: updated release action testing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,86 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up small cache
+        id: cache-small-data
+        uses: actions/cache@v3
+        with:
+          path: tests/data
+          key: ${{ runner.os }}-small-v1-${{ hashFiles('tests/data/small-114.zip') }}
+          restore-keys: |
+            ${{ runner.os }}-small-v1-
+
+      - name: Check cache status
+        run: |
+          echo "Cache hit: ${{ steps.cache-small-data.outputs.cache-hit }} ***"
+
+      - name: Download small data file
+        if: steps.cache-small-data.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tests/data/small-114.zip "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+
+      - name: Set up apes installed cache
+        id: cache-apes-data
+        uses: actions/cache@v3
+        with:
+          path: tests/data
+          key: ${{ runner.os }}-apes-v1-${{ hashFiles('tests/data/apes-114.zip') }}
+          restore-keys: |
+            ${{ runner.os }}-apes-v1-
+
+      - name: Check apes data cache status
+        run: |
+          echo "Cache hit: ${{ steps.cache-apes-data.outputs.cache-hit }} ***"
+
+      - name: Download apes installation data file
+        if: steps.cache-apes-data.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tests/data/apes-114.zip "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
+
+      - name: Set up apes maf cache
+        id: cache-apes-data-maf
+        uses: actions/cache@v3
+        with:
+          path: tests/data
+          key: ${{ runner.os }}-apes-maf-v1-${{ hashFiles('tests/data/apes-114-maf.zip') }}
+          restore-keys: |
+            ${{ runner.os }}-apes-maf-v1-
+
+      - name: Check apes maf cache status
+        run: |
+          echo "Cache hit: ${{ steps.cache-apes-data-maf.outputs.cache-hit }} ***"
+
+      - name: Download apes maf data file
+        if: steps.cache-apes-data-maf.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tests/data/apes-114-maf.zip "https://www.dropbox.com/scl/fi/9kc57hitzhwwifq35je8l/apes-114-maf.zip?rlkey=mxeytmuv672cpfar7iirh7emm&dl=1"
+
+      - name: Unzip data files
+        run: |
+          cd tests/data
+          unzip -o -q small-114.zip
+          unzip -o -q apes-114.zip
+          unzip -o -q apes-114-maf.zip
+
       - uses: "actions/setup-python@v5"
         with:
             python-version: "${{ matrix.python-version }}"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
       - name: "Installs for ${{ matrix.python-version }}"
         run: |
-          pip install --upgrade pip
-          pip install nox uv
+          uv venv venv -p python${{ matrix.python-version }}
+          uv tool install -p venv nox
 
-      - name: "Run nox for Python ${{ matrix.python-version }}"
-        run: "nox -db uv -s test-${{ matrix.python-version }} -- -m 'not internet'"
+      - name: "Run nox for ${{ matrix.python-version }}"
+        run: |
+          nox -db uv --force-python python -s test -- -m 'not internet'
+
 
   build:
     name: Build wheel and sdist


### PR DESCRIPTION
## Summary by Sourcery

Optimize the GitHub Actions release workflow by caching test data archives, switching to astral-sh/setup-uv for environment and tool installation, and updating nox test execution.

CI:
- Add separate cache steps for small, apes, and apes-maf data archives in the release workflow and unzip them on cache miss
- Replace pip-based installation with astral-sh/setup-uv for virtualenv creation and nox tool setup
- Streamline nox test runs to use uv-managed environments and force the appropriate Python version