### PR TITLE
DEV: add docs link to pyproject.toml and bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version", "description"]
 
 [project.urls]
-Documentation = "https://github.com/cogent3/ensembl_tui"
+Documentation = "https://ensembl-tui.readthedocs.io/"
 "Bug Tracker" = "https://github.com/cogent3/ensembl_tui/issues"
 "Source Code" = "https://github.com/cogent3/ensembl_tui"
 

--- a/src/ensembl_tui/__init__.py
+++ b/src/ensembl_tui/__init__.py
@@ -6,4 +6,4 @@ filterwarnings("ignore", message=".*MPI")
 filterwarnings("ignore", message="Can't drop database.*")
 filterwarnings("ignore", message="A worker stopped while some jobs.*")
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
## Summary by Sourcery

Update project metadata for release

Enhancements:
- Update documentation URL in pyproject.toml to point to ReadTheDocs

Chores:
- Bump package version from 0.4.0 to 0.4.1