### PR TITLE
DOC: fix doc error arising from cogent3 bug

### DIFF
--- a/docs/sample-alignments.md
+++ b/docs/sample-alignments.md
@@ -32,5 +32,4 @@ aln = loader(align_dir[0])
 # remove the alignment columns containing any degenerate character
 # by default this includes the gap character
 aln2 = aln.no_degenerates()
-print(aln2[:200].to_pretty(wrap=60))
 ```


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove the print example line from sample-alignments.md to match current cogent3 behavior