### PR TITLE
Misc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,7 @@ $ ls demo/
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ head -n 5 demo/species.tsv
 ```
+
 ### The config contents
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
@@ -53,10 +54,10 @@ For now, you must include `db=core` under the species section.
 
 Sources from the Compara database are indicated here. Including `homologies =` (without a value) indicates that you want to get the homology information for all the selected species.
 
-You can indicate the alignments you want as comma separated values assigned to the variable `align_names`. 
+You can indicate the alignments you want as comma separated values assigned to the variable `align_names`.
 
-> **Note**
-> To select the alignments that you want, you will need to navigate the Ensembl FTP site for the release you are interested in.
+!!! note
+    To select the alignments that you want, you will need to navigate the Ensembl FTP site for the release you are interested in.
 
 ## Implicit selection of genomes
 
@@ -79,7 +80,5 @@ homologies =
 ```
 
 ```bash exec="1" workdir="./docs"
-echo `pwd`
-rm -rf demo
-ls
+rm -rf demo  # markdown-exec: hide
 ```

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,5 +8,5 @@ In addition to writing the original files from Ensembl, an expanded version of t
 $ eti download -c example/sample.cfg
 ```
 
-> **Note**
-> Downloading takes advantage of multiple threads and can be interrupted and resumed.
+!!! note
+    Downloading takes advantage of multiple threads and can be interrupted and resumed.

--- a/docs/genome.md
+++ b/docs/genome.md
@@ -5,8 +5,9 @@
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti installed -i data/apes-114
 ```
-> **Note**
-> :material-download: [Download all the data](ensembl_tui_data.zip) (zip, ~196 MB).
+
+!!! note
+    :material-download: [Download all the data](ensembl_tui_data.zip) (zip, ~196 MB).
 
 ## Summary for a species {#summary-species}
 
@@ -16,8 +17,8 @@ $ eti species-summary -i data/apes-114 --species human
 
 ## Export gene meta-data for a species {#export-genes}
 
-> **Note**
-> The list of data from this query only covers human chromosome 22 because we are using a custom subset of the original Ensembl data.
+!!! note
+   The list of data from this query only covers human chromosome 22 because we are using a custom subset of the original Ensembl data.
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti dump-genes -i data/apes-114 --species human -od human_data
@@ -32,11 +33,11 @@ $ head human_data/homo_sapiens-114-gene_metadata.tsv
 In order to utilize `ensembl-tui` for sampling non-genic regions you need to write code that will produce a coordinate file. We're going to do that here using `cogent3`. In brief, the algorithmic steps are
 
 1. Load the metadata file into a `cogent3` table
-2. Sort the table by the genomic coordinate columns seqid, start, stop
-3. For each seqid (e.g. "22" for chromosome 22)
-4. Get the start, stop coordinates for all genes and merge overlapping
-5. Defining intergenic as last gene stop and current gene start
-6. Write these out to a tab delimited file with the correct column headings
+1. Sort the table by the genomic coordinate columns seqid, start, stop
+1. For each seqid (e.g. "22" for chromosome 22)
+1. Get the start, stop coordinates for all genes and merge overlapping
+1. Defining intergenic as last gene stop and current gene start
+1. Write these out to a tab delimited file with the correct column headings
 
 ```python exec="on" result="ansi" workdir="./docs" source="above"
 from cogent3 import load_table, make_table
@@ -66,10 +67,12 @@ strand = 1
 inter_genic = [(species, seqid, 0, start_stop[0][0], strand)]
 last_end = start_stop[0][1]
 for start, stop in start_stop:
-   inter_genic.append((species, seqid, last_end, start, strand))
-   last_end = stop
+    inter_genic.append((species, seqid, last_end, start, strand))
+    last_end = stop
 
-intergen_tab = make_table(header=["species", "seqid", "start", "stop", "strand"], data=inter_genic)
+intergen_tab = make_table(
+    header=["species", "seqid", "start", "stop", "strand"], data=inter_genic
+)
 intergen_tab.write("data/chrom22-intergenic.tsv")
 ```
 

--- a/docs/genome.md
+++ b/docs/genome.md
@@ -34,33 +34,45 @@ In order to utilize `ensembl-tui` for sampling non-genic regions you need to wri
 1. Load the metadata file into a `cogent3` table
 2. Sort the table by the genomic coordinate columns seqid, start, stop
 3. For each seqid (e.g. "22" for chromosome 22)
-4. Defining intergenic as last gene stop and current gene start
-5. Write these out to a tab delimited file with the correwct column headings
+4. Get the start, stop coordinates for all genes and merge overlapping
+5. Defining intergenic as last gene stop and current gene start
+6. Write these out to a tab delimited file with the correct column headings
 
 ```python exec="on" result="ansi" workdir="./docs" source="above"
-import cogent3
+from cogent3 import load_table, make_table
+from cogent3.util.misc import get_merged_overlapping_coords
 
-table = cogent3.load_table("human_data/homo_sapiens-114-gene_metadata.tsv")
-table = table.sorted(columns=["seqid", "start", "stop"])
+table = load_table("human_data/homo_sapiens-114-gene_metadata.tsv")
 # make sure the seqid column is a string type
 table.columns["seqid"] = table.columns["seqid"].astype(str)
+table = table.sorted(columns=["seqid", "start", "stop"])
+
+# if we were doing this for real, we would work on each unique
+# seqid at a time
 seqids = table.distinct_values("seqid")
-# let's just do chrom 22 ... because that's all we have!
-chrom22 = table.filtered(lambda x: x == "22", columns="seqid")
+
+# but we just do one seqid here, chrom 22
+seqid = "22"
+chrom22 = table.filtered(lambda x: x == seqid, columns="seqid")
 start_stop = chrom22.to_list(["start", "stop"])
-inter_genic = [("22", 0, start_stop[0][0], 1)]
+
+# we use the utility function to merge overlapping gene coordinates
+start_stop = get_merged_overlapping_coords(start_stop)
+
+# define the remaining constants to be output into the tsv file
+# required by eti
+species = "homo_sapiens"
+strand = 1
+inter_genic = [(species, seqid, 0, start_stop[0][0], strand)]
 last_end = start_stop[0][1]
 for start, stop in start_stop:
-   inter_genic.append(("22", last_end, start, 1))
+   inter_genic.append((species, seqid, last_end, start, strand))
    last_end = stop
 
-intergen_tab = cogent3.make_table(header=["seqid", "start", "stop", "strand"], data=inter_genic)
+intergen_tab = make_table(header=["species", "seqid", "start", "stop", "strand"], data=inter_genic)
 intergen_tab.write("data/chrom22-intergenic.tsv")
 ```
 
 ```bash exec="1"
 rm -rf human_data # markdown-exec: hide
 ```
-
-> **Warning**
-> The above does not handle the case where genes overlap!

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,12 +8,11 @@
 pip install ensembl-tui
 ```
 
-> **NOTE**
-> If you experience any errors during installation, we recommend using [uv pip](https://docs.astral.sh/uv/). This command provides much better error messages than the standard `pip` command. If you cannot resolve the installation problem, please [open an issue](https://github.com/cogent3/ensembl_tui/issues).
+!!! note
+    If you experience any errors during installation, we recommend using [uv pip](https://docs.astral.sh/uv/). This command provides much better error messages than the standard `pip` command. If you cannot resolve the installation problem, please [open an issue](https://github.com/cogent3/ensembl_tui/issues).
 
-
-> **Note**
-> The first usage of `ensembl-tui` is slow because both `cogent3` and `ensembl-tui` are compiling some functions. This is a one-time cost.
+!!! note
+    The first usage of `ensembl-tui` is slow because both `cogent3` and `ensembl-tui` are compiling some functions. This is a one-time cost.
 
 ## Installation And Usage With `uv`
 
@@ -38,9 +37,11 @@ To see the options for `eti` or one of its subcommands, just enter the expressio
 ```console exec="1" source="console" result="ansi" workdir="./docs" returncode="2"
 $ eti
 ```
+
 lists all of the subcommands. While
 
 ```console exec="1" source="console" result="ansi" workdir="./docs" returncode="2"
 $ eti download
 ```
+
 shows the options for the download command.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installing Ensembl Data
 
-The install step converts the downloaded data into more efficient data structures. These are written to the `install_path` as specified in the config file. 
+The install step converts the downloaded data into more efficient data structures. These are written to the `install_path` as specified in the config file.
 
 The install command requires the path to the download directory.
 
@@ -8,8 +8,8 @@ The install command requires the path to the download directory.
 $ eti install -d <dirname>
 ```
 
-> **Note**
-> You can utilize multiple processes on your machine for this installation step with the `-np #` argument. We recommend specifying the same number of processes as the number of genomes, e.g. `-np 10` for ten genomes.
+!!! note
+    You can utilize multiple processes on your machine for this installation step with the `-np #` argument. We recommend specifying the same number of processes as the number of genomes, e.g. `-np 10` for ten genomes.
 
 ## Check Your Installation
 
@@ -19,8 +19,8 @@ Once you have finished your installation, you can check its contents using the `
 $ eti installed -i data/apes-114
 ```
 
-> **Note**
-> Here we start specifying the installation directory using the `-i` option. This is required for all commands that reference an installation.
+!!! note
+    Here we start specifying the installation directory using the `-i` option. This is required for all commands that reference an installation.
 
-> **Warning**
-> At, present installation is not interruptible. If you need to reinstall, you will need to force overwriting of the current installation using the `--force_overwrite`` argument.
+!!! warning
+    At present, installation is not interruptible. If you need to reinstall, you will need to force overwriting of the current installation using the `--force_overwrite` argument.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,11 +5,11 @@ Installation of `ensembl-tui` creates a command line tool `eti` which contains a
 In this quick start, we'll perform the following steps:
 
 1. Create a demo config file
-2. Download raw data from Ensembl
-3. Make the local installation
-4. Show summaries of the installation
-5. Export gene meta-data
-6. Export homology data
+1. Download raw data from Ensembl
+1. Make the local installation
+1. Show summaries of the installation
+1. Export gene meta-data
+1. Export homology data
 
 ## Create A Demo Config
 
@@ -19,10 +19,10 @@ You specify the genomic resources that you want from Ensembl using a config file
 $ eti demo-config -o demo
 ```
 
-> **Note**
-> The config specifies download the genomes and annotations from Ensembl release 114 of  *Saccharomyces cerevisiae* and *Caenorhabditis elegans* and gene homology data. It also specifies the path to write the downloaded files and where to install them.
+!!! note
+    The config specifies download the genomes and annotations from Ensembl release 114 of *Saccharomyces cerevisiae* and *Caenorhabditis elegans* and gene homology data. It also specifies the path to write the downloaded files and where to install them.
 
-> **Warning**
+> [!WARNING]
 > Edit this file before using! It also specifies primate whole genome alignments -- which are large!
 
 ## Download The Specified Data
@@ -32,10 +32,11 @@ We use a custom config file which specifies just bakers yeast the the worm. (You
 ```
 $ eti download -c <path to>/small.cfg
 ```
+
 The data will be downloaded to `staging_path` specified in `small.cfg`, which is interpreted relative to the directory in which you executed the command.
 
-> **Note**
-> Downloads can be interrupted.
+!!! note
+    Downloads can be interrupted.
 
 ## Make The Local Installation
 
@@ -62,7 +63,8 @@ $ eti species-summary -i data/small-install --species saccharomyces_cerevisiae
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti compara-summary -i data/small-install
 ```
- This shows the relationships between the species installed.
+
+This shows the relationships between the species installed.
 
 ## Export Gene meta-data
 
@@ -81,11 +83,12 @@ $ head -n 5 yeast/saccharomyces_cerevisiae*.tsv
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti homologs -i data/small-install --ref caenorhabditis_elegans --outdir worm_yeast --homology_type ortholog_one2one --limit 5
 ```
+
 Listing the files that are written into the specified `worm_yeast` directory.
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ ls worm_yeast
 ```
 
-> **Note**
-> The `not_completed` directory will contain any errors that occurred during the homolog command.
+!!! note
+    The `not_completed` directory will contain any errors that occurred during the homolog command.

--- a/docs/sample-alignments.md
+++ b/docs/sample-alignments.md
@@ -12,7 +12,6 @@ Identifying introns is achieved using `--mask cds`. Masking follows the [cogent3
 
 This above command command produces a directory called `apes_aligns` and individual alignments are at the top level in this directory ending in `.fa`. We show the outcome of the mask option for one of the alignment files produced. We also show how to remove alignment columns containing any degenerate character (as define by the `moltype`), by default this includes the gap character.
 
-
 ```python exec="on" result="ansi" workdir="./docs" source="above"
 import cogent3
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ hooks:
     - docs/scripts/setup_data.py
 
 markdown_extensions:
+- admonition
 - attr_list
 - pymdownx.superfences
 - pymdownx.emoji:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
     "pytest-cov",
     "pytest-timeout",
     "pytest-xdist",
-    "ruff==0.10.0",
+    "ruff==0.12.10",
     "nox"]
 doc  = [
     "ensembl-tui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ doc  = [
     "markdown-exec[ansi]>=1.10.0",
     "mkdocs-jupyter>=0.25.1",
     "markdown>=3.7",
+    "mdformat",
+    "mdformat-mkdocs",
+    "mdformat-black",
 ]
 dev = ["click",
        "cogapp",


### PR DESCRIPTION
## Summary by Sourcery

Revise the genome documentation example to use cogent3 utilities for merging overlapping gene coordinates and include species and strand metadata, and bump the ruff linter version.

Build:
- Bump ruff dependency from 0.10.0 to 0.12.10 in pyproject.toml.

Documentation:
- Update docs/genome.md to replace manual coordinate operations with load_table, make_table, and get_merged_overlapping_coords for intergenic extraction and add species/strand columns in the output.