### PR TITLE
DEV: pin working dependency versions

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -42,7 +42,7 @@ small-113/*
 docs/data/*-114/*
 tests/data/*-114/*
 tests/data/prep_tests_data/*-114*
-docs/data/*114*
+docs/data/*
 tests/data/*114*
 site/*
 ensembl_tui_data.zip

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,7 @@ _py_versions = range(10, 14)
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
     session.install("-e.[test]")
+    session.run("pip", "list")
     session.chdir("tests")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = ["blosc2",
         "click",
-        "cogent3>=2025.7.10a5",
-        "cogent3-h5seqs",
+        "cogent3==2025.7.10a5",
+        "cogent3-h5seqs==0.5.0",
         "duckdb",
         "numba",
         "numpy",

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -602,14 +602,20 @@ def alignments(
         for alignments in maker.as_completed(locations, show_progress=False):
             progress_bar.update(task, advance=1)
             if not alignments:
-                eti_util.print_colour(str(alignments), colour="red")
+                if verbose:
+                    eti_util.print_colour(str(alignments), colour="red")
                 continue
+
             input_source = alignments[0].info.source
             if len(alignments) == 1:
                 writer(alignments[0], identifier=input_source)
                 continue
 
             for i, aln in enumerate(alignments):
+                if len(aln) == 0:
+                    if verbose:
+                        eti_util.print_colour(text=f"{aln=}", colour="red")
+                    continue
                 identifier = f"{input_source}-{i}"
                 writer(aln, identifier=identifier)
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -542,7 +542,7 @@ def test_aligndb_post_init_failure(tmp_path):
 
 def test_aligndb_close(db_align):
     db_align.close()
-    with pytest.raises(duckdb.duckdb.ConnectionException):
+    with pytest.raises(duckdb.ConnectionException):
         db_align.num_records()
 
 


### PR DESCRIPTION
## Summary by Sourcery

Pin key dependencies to exact versions, improve CLI logging under verbose mode, correct the exception type in tests, and surface installed packages during CI runs

Bug Fixes:
- Update test to catch duckdb.ConnectionException instead of duckdb.duckdb.ConnectionException

Enhancements:
- Only print empty alignment messages in verbose mode
- Add pip list command to nox test session for debugging

Chores:
- Pin cogent3 and cogent3-h5seqs to exact versions in pyproject.toml