### PR TITLE
ENH: refactor site map class to take over responsibilities from Config

### DIFF
--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -1,5 +1,4 @@
 import typing
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cache
 
@@ -42,14 +41,26 @@ class register_ensembl_site_map:
 StrOrNone = typing.Union[str, type(None)]
 
 
-class SiteMapABC(ABC):
-    @abstractmethod
-    def get_seqs_path(self, ensembl_name: str) -> str:
-        """returns the path to genome sequences for species_db_name"""
-        ...
+@dataclass(slots=True)
+class SiteMap:
+    """records the locations of specific attributes relative to an Ensembl release"""
 
-    @abstractmethod
-    def get_annotations_path(self, ensembl_name: str) -> str: ...
+    site: str
+    db_host: str
+    db_port: int
+    remote_path: str
+    _seqs_path: str = "fasta"
+    _annotations_path: str = "mysql"
+    _alignments_path: str | None = None
+    _homologies_path: str | None = None
+    _trees_path: str | None = None
+
+    def get_seqs_path(self, ensembl_name: str) -> str:
+        """path to unmasked genome sequences"""
+        return f"{self._seqs_path}/{ensembl_name}/dna"
+
+    def get_annotations_path(self, ensembl_name: str) -> str:
+        return f"{self._annotations_path}/{ensembl_name}"
 
     @property
     def alignments_path(self) -> StrOrNone:
@@ -63,40 +74,36 @@ class SiteMapABC(ABC):
     def trees_path(self) -> StrOrNone:
         return self._trees_path
 
-
-@dataclass(slots=True)
-class SiteMap:
-    """records the locations of specific attributes relative to an Ensembl release"""
-
-    site: str
-    _seqs_path: str = "fasta"
-    _annotations_path: str = "mysql"
-    _alignments_path: str | None = None
-    _homologies_path: str | None = None
-    _trees_path: str | None = None
-
-
-class EnsemblPrimary(SiteMapABC, SiteMap):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
-    def get_seqs_path(self, ensembl_name: str) -> str:
-        """path to unmasked genome sequences"""
-        return f"{self._seqs_path}/{ensembl_name}/dna"
-
-    def get_annotations_path(self, ensembl_name: str) -> str:
-        return f"{self._annotations_path}/{ensembl_name}"
+    def get_remote_release_path(self, release: str) -> str:
+        return f"{self.remote_path}/release-{release}"
 
 
 @extend_docstring_from(SiteMap)
 @register_ensembl_site_map("ftp.ensembl.org")
-def ensembl_main_sitemap():
+def ensembl_main_sitemap() -> SiteMap:
     """the main Ensembl site map"""
-    return EnsemblPrimary(
+    return SiteMap(
         site="ftp.ensembl.org",
         _alignments_path="maf/ensembl-compara/multiple_alignments",
         _homologies_path="tsv/ensembl-compara/homologies",
         _trees_path="compara/species_trees",
+        db_host="ensembldb.ensembl.org",
+        db_port=3306,
+        remote_path="pub",
+    )
+
+
+@register_ensembl_site_map("ftp.ensemblgenomes.org")
+def ensembl_metazoa_sitemap() -> SiteMap:
+    """the main Ensembl site map"""
+    return SiteMap(
+        site="ftp.ensemblgenomes.org",
+        _alignments_path=None,
+        _homologies_path="tsv/ensembl-compara/homologies",
+        _trees_path=None,
+        db_host="mysql-eg-publicsql.ebi.ac.uk",
+        db_port=4157,
+        remote_path="pub/metazoa",
     )
 
 
@@ -112,6 +119,6 @@ def ensembl_main_sitemap():
 
 
 @cache
-def get_site_map(domain: str) -> SiteMapABC:
+def get_site_map(domain: str) -> SiteMap:
     """returns a site map instance"""
     return _ensembl_site_map[domain]()


### PR DESCRIPTION
[CHANGED] remove the ABC for now and just have a single SiteMap
    class. Premature optimisation and all that.

[NEW] Expand SiteMap to include the db_host, db_port, remote_path
    and added a method for getting the remote path for a specified
    Ensembl release.

[NEW] Added new instance for the Ensembl metazoa site.

## Summary by Sourcery

Unify and expand the SiteMap implementation by removing the abstract base class, consolidating path properties, and introducing database and remote path attributes along with support for a Metazoa site map.

New Features:
- Expose database host, port, and remote path as attributes in SiteMap
- Add get_remote_release_path method to compute the remote path for specific releases
- Register a new site map instance for Ensembl Metazoa

Enhancements:
- Remove the SiteMapABC abstract base class and consolidate functionality into a single SiteMap class
- Promote alignment, homology, and tree path properties to the SiteMap class