### PR TITLE
MAINT: address cogent3 deprecation of TreeNode

### DIFF
--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 
+from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
@@ -285,6 +286,7 @@ def read_config(
     host = parser.get("remote path", "host")
     remote_path = parser.get("remote path", "path")
     remote_path = remote_path.removesuffix("/")
+    site_map = eti_site_map.get_site_map(host)
     # paths
     staging_path = _standardise_path(parser.get("local path", "staging_path"), root_dir)
     install_path = _standardise_path(parser.get("local path", "install_path"), root_dir)
@@ -317,7 +319,12 @@ def read_config(
     if tree_names:
         # add all species in the tree to species_dbs
         for tree_name in tree_names:
-            tree = download_ensembl_tree(host, remote_path, release, tree_name)
+            tree = download_ensembl_tree(
+                host=host,
+                release=release,
+                site_map=site_map,
+                tree_fname=tree_name,
+            )
             sp = eti_species.species_from_ensembl_tree(tree)
             species_dbs |= sp
 

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -15,6 +15,9 @@ from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
+if typing.TYPE_CHECKING:
+    from cogent3.core.tree import PhyloNode
+
 DEFAULT_CFG = eti_util.get_resource_path("sample.cfg")
 
 _valid_seq = re.compile(r"dna[.](nonchromosomal|toplevel)\.fa\.gz")
@@ -327,7 +330,7 @@ def download_ensembl_tree(
     remote_path: str,
     release: str,
     tree_fname: str,
-) -> cogent3.core.tree.PhyloNode:
+) -> "PhyloNode":
     """loads a tree from Ensembl"""
     site_map = eti_site_map.get_site_map(host)
     url = f"https://{host}/{remote_path}/release-{release}/{site_map.trees_path}/{tree_fname}"

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -47,8 +47,11 @@ def _remove_tmpdirs(path: eti_util.PathType) -> None:
 
 def get_core_db_dirnames(config: eti_config.Config) -> dict[str, str]:
     """maps species name to ftp path to mysql core dbs"""
+    site_map = eti_site_map.get_site_map(config.host)
+    remote_release_path = site_map.get_remote_release_path(config.release)
+    # get all the mysql db names
     all_db_names = list(
-        eti_ftp.listdir(config.host, f"{config.remote_release_path}/mysql"),
+        eti_ftp.listdir(config.host, f"{remote_release_path}/mysql"),
     )
     selected_species = {}
     for db_name in all_db_names:
@@ -107,14 +110,16 @@ def make_core_db_templates(
 
 
 def download_species(
+    *,
+    site_map: eti_site_map.SiteMap,
     config: eti_config.Config,
     debug: bool,
     verbose: bool,
     progress: Progress | None = None,
 ) -> None:
     """download seq and annotation data"""
-    remote_template = f"{config.remote_release_path}/" + "{}"
-    site_map = eti_site_map.get_site_map(config.host)
+    remote_release_path = site_map.get_remote_release_path(config.release)
+    remote_template = f"{remote_release_path}/" + "{}"
     if verbose:
         eti_util.print_colour(
             text=f"DOWNLOADING\n  ensembl release={config.release}",
@@ -208,7 +213,9 @@ class valid_compara_align:  # noqa: N801
 
 
 def download_aligns(
+    *,
     config: eti_config.Config,
+    site_map: eti_site_map.SiteMap,
     debug: bool,
     verbose: bool,
     progress: Progress | None = None,
@@ -217,10 +224,7 @@ def download_aligns(
     if not config.align_names:
         return
 
-    site_map = eti_site_map.get_site_map(config.host)
-    remote_template = (
-        f"{config.remote_path}/release-{config.release}/{site_map.alignments_path}/{{}}"
-    )
+    remote_template = f"{site_map.remote_path}/release-{config.release}/{site_map.alignments_path}/{{}}"
 
     msg = "Downloading alignments"
     if progress is not None:
@@ -271,19 +275,18 @@ class valid_compara_homology:  # noqa: N801
 
 
 def download_homology(
+    *,
     config: eti_config.Config,
     debug: bool,
     verbose: bool,
+    site_map: eti_site_map.SiteMap,
     progress: Progress | None = None,
 ) -> None:
     """downloads tsv homology files for each genome"""
     if not config.homologies:
         return
 
-    site_map = eti_site_map.get_site_map(config.host)
-    remote_template = (
-        f"{config.remote_path}/release-{config.release}/{site_map.homologies_path}/{{}}"
-    )
+    remote_template = f"{site_map.remote_path}/release-{config.release}/{site_map.homologies_path}/{{}}"
 
     local = config.staging_homologies
 
@@ -326,44 +329,50 @@ def download_homology(
 
 
 def download_ensembl_tree(
+    *,
     host: str,
-    remote_path: str,
+    site_map: eti_site_map.SiteMap,
     release: str,
     tree_fname: str,
 ) -> "PhyloNode":
     """loads a tree from Ensembl"""
-    site_map = eti_site_map.get_site_map(host)
-    url = f"https://{host}/{remote_path}/release-{release}/{site_map.trees_path}/{tree_fname}"
+    url = f"https://{host}/{site_map.remote_path}/release-{release}/{site_map.trees_path}/{tree_fname}"
     return cogent3.load_tree(url)
 
 
-def get_ensembl_trees(host: str, remote_path: str, release: str) -> list[str]:
+def get_ensembl_trees(
+    *,
+    host: str,
+    release: str,
+    site_map: eti_site_map.SiteMap,
+) -> list[str]:
     """returns trees from ensembl compara"""
-    site_map = eti_site_map.get_site_map(host)
-    path = f"{remote_path}/release-{release}/{site_map.trees_path}"
+    path = f"{site_map.remote_path}/release-{release}/{site_map.trees_path}"
     return list(
         eti_ftp.listdir(host=host, path=path, pattern=lambda x: x.endswith(".nh")),
     )
 
 
 def get_species_for_alignments(
+    *,
     host: str,
     remote_path: str,
     release: str,
     align_names: typing.Iterable[str],
+    site_map: eti_site_map.SiteMap,
 ) -> dict[str, list[str]]:
     """return the species for the indicated alignments"""
     ensembl_trees = get_ensembl_trees(
+        site_map=site_map,
         host=host,
-        remote_path=remote_path,
         release=release,
     )
     aligns_trees = eti_util.trees_for_aligns(align_names, ensembl_trees)
     species = {}
     for tree_path in aligns_trees.values():
         tree = download_ensembl_tree(
+            site_map=site_map,
             host=host,
-            remote_path=remote_path,
             release=release,
             tree_fname=pathlib.Path(tree_path).name,
         )

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -3,7 +3,7 @@ import pathlib
 import typing
 
 from cogent3 import load_table, make_table
-from cogent3.core.tree import TreeNode
+from cogent3.core.tree import PhyloNode
 
 from ensembl_tui import _util as eti_util
 
@@ -197,7 +197,7 @@ class SpeciesNameMap:
 Species = SpeciesNameMap()
 
 
-def species_from_ensembl_tree(tree: TreeNode) -> dict[str, str]:
+def species_from_ensembl_tree(tree: PhyloNode) -> dict[str, str]:
     """get species identifiers from an Ensembl tree"""
     tip_names = tree.get_tip_names()
     selected_species = {}

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -14,6 +14,7 @@ from ensembl_tui import _cli_option as cli_opt
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _homology as eti_homology
+from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
@@ -94,6 +95,7 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
         sys.exit(1)
 
     config = eti_config.read_config(configpath, root_dir=pathlib.Path.cwd())
+    site_map = eti_site_map.get_site_map(config.host)
 
     if verbose:
         eti_util.print_colour(text=str(config), colour="yellow")
@@ -104,6 +106,7 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
 
     if not config.species_dbs:
         species = eti_download.get_species_for_alignments(
+            site_map=site_map,
             host=config.host,
             remote_path=config.remote_path,
             release=config.release,
@@ -125,9 +128,27 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
             progress.TimeElapsedColumn(),
         ) as prog_bar,
     ):
-        eti_download.download_species(config, debug, verbose, progress=prog_bar)
-        eti_download.download_homology(config, debug, verbose, progress=prog_bar)
-        eti_download.download_aligns(config, debug, verbose, progress=prog_bar)
+        eti_download.download_species(
+            site_map=site_map,
+            config=config,
+            debug=debug,
+            verbose=verbose,
+            progress=prog_bar,
+        )
+        eti_download.download_homology(
+            site_map=site_map,
+            config=config,
+            debug=debug,
+            verbose=verbose,
+            progress=prog_bar,
+        )
+        eti_download.download_aligns(
+            site_map=site_map,
+            config=config,
+            debug=debug,
+            verbose=verbose,
+            progress=prog_bar,
+        )
 
     eti_util.print_colour(text=f"Downloaded to {config.staging_path}", colour="green")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from ensembl_tui import _align as eti_align
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _download as eti_download
+from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _util as eti_util
 
 
@@ -149,12 +150,14 @@ def test_read_config_compara_genomes(cfg_just_aligns):
     from ensembl_tui._species import Species
 
     config = eti_config.read_config(cfg_just_aligns)
+    site_map = eti_site_map.get_site_map(config.host)
     assert not config.species_dbs
     sp = eti_download.get_species_for_alignments(
         host=config.host,
         remote_path=config.remote_path,
         release=config.release,
         align_names=config.align_names,
+        site_map=site_map,
     )
     expected = {Species.get_species_name(n) for n in COMMON_NAMES}
     assert set(sp.keys()) == expected


### PR DESCRIPTION
## Summary by Sourcery

Replace deprecated cogent3 TreeNode references with PhyloNode type hints to align with cogent3 deprecations.

Enhancements:
- Replace TreeNode with PhyloNode in function annotations
- Import PhyloNode under TYPE_CHECKING and use forward references in return types