### PR TITLE
Simplify config object and settings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -34,7 +34,7 @@ This is a `.ini` format. A section is denoted by square brackets surrounding the
 
 ### `[remote path]`
 
-This is the section defining which Ensembl FTP server hosts the data and the remote path. At present, we are only supporting the primary Ensembl Server, so this section should be left as is.
+This is the section defining which Ensembl FTP server hosts the data. At present, we are only supporting the primary Ensembl Server, so this section should be left as is.
 
 ### `[local path]`
 
@@ -68,7 +68,6 @@ For example, the following config would download 10 primate genomes along with w
 ```ini
 [remote path]
 host=ftp.ensembl.org
-path=pub
 [local path]
 staging_path=download_114
 install_path=install_114

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -105,7 +105,7 @@ class Config:
             install_path = str(make_relative_to(self.staging_path, self.install_path))
 
         data = {
-            "remote path": {"path": str(self.remote_path), "host": str(self.host)},
+            "remote path": {"host": str(self.host)},
             "local path": {
                 "staging_path": staging_path,
                 "install_path": install_path,

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -37,7 +37,6 @@ def make_relative_to(
 @dataclass
 class Config:
     host: str
-    remote_path: str
     release: str
     staging_path: pathlib.Path
     install_path: pathlib.Path
@@ -49,10 +48,6 @@ class Config:
     def __post_init__(self) -> None:
         self.staging_path = pathlib.Path(self.staging_path)
         self.install_path = pathlib.Path(self.install_path)
-
-    @property
-    def remote_release_path(self) -> str:
-        return f"{self.remote_path}/release-{self.release}"
 
     @property
     def staging_template_path(self) -> pathlib.Path:
@@ -284,8 +279,6 @@ def read_config(
 
     release = parser.get("release", "release")
     host = parser.get("remote path", "host")
-    remote_path = parser.get("remote path", "path")
-    remote_path = remote_path.removesuffix("/")
     site_map = eti_site_map.get_site_map(host)
     # paths
     staging_path = _standardise_path(parser.get("local path", "staging_path"), root_dir)
@@ -330,7 +323,6 @@ def read_config(
 
     return Config(
         host=host,
-        remote_path=remote_path,
         release=release,
         staging_path=staging_path,
         install_path=install_path,

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -68,7 +68,9 @@ def get_remote_mysql_paths(db_name: str) -> list[str]:
 
 
 def make_core_db_templates(
+    *,
     config: eti_config.Config,
+    site_map: eti_site_map.SiteMap,
     sp_db_map: dict[str, str],
     progress: Progress | None = None,
 ) -> None:
@@ -82,6 +84,8 @@ def make_core_db_templates(
         mapping of species to mysql db names
     progress
         rich.progress context manager for tracking progress
+    site_map
+        site map stores attributes key attributes for the Ensembl site
 
     Notes
     -----
@@ -104,6 +108,8 @@ def make_core_db_templates(
             dest_dir=template_dest,
             db_name=db_name,
             table_name=table_name,
+            db_host=site_map.db_host,
+            db_port=site_map.db_port,
         )
         if progress is not None:
             progress.update(make_templates, description=msg, advance=1)
@@ -137,7 +143,12 @@ def download_species(
     sp_db_map = get_core_db_dirnames(config)
 
     # create the duckdb templates for the tables, if they don't exist
-    make_core_db_templates(config, sp_db_map, progress=progress)
+    make_core_db_templates(
+        config=config,
+        sp_db_map=sp_db_map,
+        site_map=site_map,
+        progress=progress,
+    )
 
     msg = "Downloading genomes"
     if progress is not None:
@@ -356,7 +367,6 @@ def get_ensembl_trees(
 def get_species_for_alignments(
     *,
     host: str,
-    remote_path: str,
     release: str,
     align_names: typing.Iterable[str],
     site_map: eti_site_map.SiteMap,

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -108,7 +108,6 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
         species = eti_download.get_species_for_alignments(
             site_map=site_map,
             host=config.host,
-            remote_path=config.remote_path,
             release=config.release,
             align_names=config.align_names,
         )

--- a/src/ensembl_tui/data/sample.cfg
+++ b/src/ensembl_tui/data/sample.cfg
@@ -1,7 +1,6 @@
 [remote path]
 # Specify which Ensembl domain to get the data from.
 host=ftp.ensembl.org
-path=pub
 [local path]
 # Local paths correspond to where the data will be downloaded
 # and where the installation will be placed.

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -491,7 +491,6 @@ def db_align(DATA_DIR, tmp_dir):
 
     cfg = eti_config.Config(
         host="localhost",
-        remote_path="",
         staging_path=staging_path,
         install_path=install_path,
         species_dbs={},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -154,7 +154,6 @@ def test_read_config_compara_genomes(cfg_just_aligns):
     assert not config.species_dbs
     sp = eti_download.get_species_for_alignments(
         host=config.host,
-        remote_path=config.remote_path,
         release=config.release,
         align_names=config.align_names,
         site_map=site_map,


### PR DESCRIPTION
## Summary by Sourcery

Simplify configuration by removing the remote_path setting, leveraging SiteMap for host and port details, updating function interfaces and implementations, and cleaning up related docs and sample configuration

Enhancements:
- Remove remote_path attribute and related property from Config
- Introduce site_map parameter to download utilities and use its db_host/db_port instead of a separate remote_path
- Update function signatures and calls to replace remote_path usage with site_map

Documentation:
- Remove path field from remote path section and update documentation and sample config