### PR TITLE
ENH: add core software versions to installed.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ eti = "ensembl_tui.cli:main"
 
 [project.optional-dependencies]
 test = [
-    "click",
     "pandas",
     "pytest",
     "pytest-cov",
@@ -66,8 +65,6 @@ test = [
     "ruff==0.12.10",
     "nox"]
 doc  = [
-    "ensembl-tui",
-    "diverse_seq[extra]",
     "mkdocs>=1.6.1",
     "markdown-exec[ansi]>=1.10.0",
     "mkdocs-jupyter>=0.25.1",
@@ -76,10 +73,8 @@ doc  = [
     "mdformat-mkdocs",
     "mdformat-black",
 ]
-dev = ["click",
-       "cogapp",
+dev = ["cogapp",
        "flit",
-       "nox",
        "numpydoc",
        "psutil",
        "scriv",

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -2,12 +2,16 @@ import configparser
 import fnmatch
 import pathlib
 import sys
+import typing
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 
 from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from cogent3.core.table import Table
 
 INSTALLED_CONFIG_NAME = "installed.cfg"
 DOWNLOADED_CONFIG_NAME = "downloaded.cfg"
@@ -16,6 +20,8 @@ _COMPARA_NAME: str = "compara"
 _ALIGNS_NAME: str = "aligns"
 _HOMOLOGIES_NAME: str = "homologies"
 _GENOMES_NAME: str = "genomes"
+
+_VERSION_SECTION = "software versions"
 
 
 def make_relative_to(
@@ -153,6 +159,7 @@ class Config:
 class InstalledConfig:
     release: str
     install_path: pathlib.Path
+    software_versions: dict[str, str]
 
     def __hash__(self) -> int:
         return id(self)
@@ -219,13 +226,49 @@ class InstalledConfig:
             raise FileNotFoundError(msg)
         return align_dir
 
+    def get_version_table(self) -> "Table":
+        """returns table of software versions used to make installation"""
+
+        from cogent3 import make_table
+
+        header = ["package", "version"]
+        return make_table(
+            header=header,
+            data=sorted(self.software_versions.items()),
+            index_name="package",
+            title="Installation software versions:",
+        )
+
+
+def _get_dependency_versions() -> dict[str, str]:
+    import re
+    from importlib import metadata
+    from importlib.util import find_spec
+
+    # get the declared dependencies
+    deps = {"ensembl_tui"}
+    for pkg in metadata.requires("ensembl_tui"):
+        if "extra" in pkg:
+            continue
+        if match := re.match(r"^[A-Za-z0-9_-]+", pkg):
+            pkg = match.group(0).replace("-", "_")
+            if find_spec(pkg):
+                deps.add(pkg)
+
+    return {pkg: metadata.version(pkg) for pkg in deps}
+
 
 def write_installed_cfg(config: Config) -> eti_util.PathType:
     """writes an ini file under config.installed_path"""
     parser = configparser.ConfigParser()
     parser.add_section("release")
     parser.set("release", "release", config.release)
-    # create all the genome
+    # get the declared dependencies
+    deps = _get_dependency_versions()
+    parser.add_section(_VERSION_SECTION)
+    for pkg, vers in deps.items():
+        parser.set(_VERSION_SECTION, pkg, vers)
+
     outpath = config.install_path / INSTALLED_CONFIG_NAME
     outpath.parent.mkdir(parents=True, exist_ok=True)
     with outpath.open(mode="w") as out:
@@ -246,7 +289,13 @@ def read_installed_cfg(path: eti_util.PathType) -> InstalledConfig:
 
     parser.read(path)
     release = parser.get("release", "release")
-    return InstalledConfig(release=release, install_path=path.parent)
+    if parser.has_section(_VERSION_SECTION):
+        software_versions = dict(parser.items(_VERSION_SECTION))
+    else:
+        software_versions = {}
+    return InstalledConfig(
+        release=release, install_path=path.parent, software_versions=software_versions
+    )
 
 
 def _standardise_path(

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -248,6 +248,12 @@ def installed(installed: pathlib.Path) -> None:
     char = "✅" if config.aligns_path.exists() else "❌"
     eti_util.print_colour(f"Installed alignments: {char}", colour="blue", style="bold")
 
+    table = config.get_version_table()
+    if table.shape[0] > 1:
+        eti_util.rich_display(table)
+    else:
+        eti_util.print_colour(f"{table.title} ❌", colour="blue", style="bold")
+
 
 @main.command(**_click_command_opts)
 @cli_opt.installed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,8 @@ def test_installed(installed):
     path = config.installed_genome("caenorhabditis_elegans")
     # should be 2 combined attr parquet files
     assert len(list(path.glob("*attr.parquet"))) == 2
+    table = config.get_version_table()
+    assert table.title in r.output
 
 
 def test_installed_with_alignments(apes_install_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,31 +11,64 @@ from ensembl_tui import _util as eti_util
 
 
 def test_installed_genome():
-    cfg = eti_config.InstalledConfig(release="110", install_path="abcd")
+    cfg = eti_config.InstalledConfig(
+        release="110", install_path="abcd", software_versions={}
+    )
     assert cfg.installed_genome("human") == pathlib.Path("abcd/genomes/homo_sapiens")
 
 
 def test_installed_aligns():
-    cfg = eti_config.InstalledConfig(release="110", install_path="abcd")
+    cfg = eti_config.InstalledConfig(
+        release="110", install_path="abcd", software_versions={}
+    )
     assert cfg.aligns_path == pathlib.Path("abcd/compara/aligns")
 
 
 def test_installed_homologies():
-    cfg = eti_config.InstalledConfig(release="110", install_path="abcd")
+    cfg = eti_config.InstalledConfig(
+        release="110", install_path="abcd", software_versions={}
+    )
     assert cfg.homologies_path == pathlib.Path("abcd/compara/homologies")
 
 
-def test_read_installed(tmp_config, tmp_path):
+@pytest.fixture
+def installed_cfg_path(tmp_config, tmp_path):
     config = eti_config.read_config(tmp_config)
     outpath = eti_config.write_installed_cfg(config)
-    got = eti_config.read_installed_cfg(outpath)
+    return outpath
+
+
+def test_read_installed(installed_cfg_path):
+    got = eti_config.read_installed_cfg(installed_cfg_path)
     assert str(got.installed_genome("human")) == str(
         got.install_path / "genomes/homo_sapiens",
     )
 
 
+def test_read_installed_software_versions(installed_cfg_path):
+    import cogent3
+    import cogent3_h5seqs
+
+    import ensembl_tui
+
+    config = eti_config.read_installed_cfg(installed_cfg_path)
+    assert config.software_versions["ensembl_tui"] == ensembl_tui.__version__
+    assert config.software_versions["cogent3"] == cogent3.__version__
+    assert config.software_versions["cogent3_h5seqs"] == cogent3_h5seqs.__version__
+
+
+def test_read_installed_get_version_table(installed_cfg_path):
+    import ensembl_tui
+
+    config = eti_config.read_installed_cfg(installed_cfg_path)
+    table = config.get_version_table()
+    assert table["ensembl_tui", "version"] == ensembl_tui.__version__
+
+
 def test_installed_config_hash():
-    ic = eti_config.InstalledConfig(release="11", install_path="abcd")
+    ic = eti_config.InstalledConfig(
+        release="11", install_path="abcd", software_versions={}
+    )
     assert hash(ic) == id(ic)
     v = {ic}
     assert len(v) == 1
@@ -50,7 +83,9 @@ def installed_aligns(tmp_path):
         dirname = align_dir / name
         dirname.mkdir(parents=True, exist_ok=True)
         (dirname / f"align_blocks.{eti_align.ALIGN_STORE_SUFFIX}").open(mode="w")
-    return eti_config.InstalledConfig(release="11", install_path=tmp_path)
+    return eti_config.InstalledConfig(
+        release="11", install_path=tmp_path, software_versions={}
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
[NEW] from the versions of ensemblk-tui's core dependencies
     in the installed.cfg

[NEW] add InstalledConfig.software_versions attribute,
     a dict[str, str] and InstalledConfig.get_version_table()
     method which returns a cogent3 table.

[NEW] add rich_display output of this to the result of the
     cli installed command. Handles the case of an older
     installation where the version info is missing.

## Summary by Sourcery

Track and report core software dependency versions by writing them to installed.cfg, exposing them via InstalledConfig, and displaying them in the CLI

New Features:
- Add software_versions attribute and get_version_table method to InstalledConfig to track package versions
- Persist a new "software versions" section in installed.cfg and read it back into InstalledConfig
- Display a formatted software versions table in the 'installed' CLI command output with fallback for missing data

Enhancements:
- Default to an empty software_versions dict when reading older installed.cfg files without version info

Build:
- Remove redundant dependencies (click, nox, ensembl-tui, diverse_seq) from test, doc, and dev sections in pyproject.toml

Tests:
- Add tests for reading software_versions from installed.cfg and for get_version_table output
- Verify CLI 'installed' command includes the software versions table title in its output