### PR TITLE
Maintenance

### DIFF
--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -8,7 +8,7 @@ from cogent3.core.tree import PhyloNode
 from ensembl_tui import _util as eti_util
 
 SPECIES_NAME = "species.tsv"
-StrOrNone = typing.Union[str, type(None)]
+StrOrNone = str | None
 
 
 def load_species(species_path: eti_util.PathType) -> list[list[str]]:

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -1,86 +1,81 @@
-from unittest import TestCase
-
 import pytest
 from cogent3.core.table import Table
 
 from ensembl_tui._species import Species
 
 
-class TestSpeciesNamemaps(TestCase):
-    def test_get_name_type(self):
-        """should return the (latin|common) name given a latin, common or ensembl
-        db prefix names"""
-        self.assertEqual(Species.get_species_name("human"), "Homo sapiens")
-        self.assertEqual(Species.get_species_name("homo_sapiens"), "Homo sapiens")
-        self.assertEqual(
-            Species.get_species_name("canis_lupus_familiaris"),
-            "Canis lupus familiaris",
-        )
-        self.assertEqual(Species.get_common_name("Mus musculus"), "Mouse")
-        self.assertEqual(Species.get_common_name("mus_musculus"), "Mouse")
+def test_get_name_type():
+    """should return the (latin|common) name given a latin, common or ensembl
+    db prefix names"""
+    assert Species.get_species_name("human") == "Homo sapiens"
+    assert Species.get_species_name("homo_sapiens") == "Homo sapiens"
+    assert (
+        Species.get_species_name("canis_lupus_familiaris") == "Canis lupus familiaris"
+    )
+    assert Species.get_common_name("Mus musculus") == "Mouse"
+    assert Species.get_common_name("mus_musculus") == "Mouse"
 
-    def test_get_ensembl_format(self):
-        """should take common or latin names and return the corresponding
-        ensembl db prefix"""
-        self.assertEqual(Species.get_ensembl_db_prefix("human"), "homo_sapiens")
-        self.assertEqual(Species.get_ensembl_db_prefix("mouse"), "mus_musculus")
-        self.assertEqual(Species.get_ensembl_db_prefix("Mus musculus"), "mus_musculus")
-        self.assertEqual(
-            Species.get_ensembl_db_prefix("Canis lupus familiaris"),
-            "canis_lupus_familiaris",
-        )
 
-    def test_add_new_species(self):
-        """should correctly add a new species/common combination and infer the
-        correct ensembl prefix"""
-        species_name, common_name = "Otolemur garnettii", "Bushbaby"
-        Species.amend_species(species_name, common_name)
-        self.assertEqual(Species.get_species_name(species_name), species_name)
-        self.assertEqual(Species.get_species_name("Bushbaby"), species_name)
-        self.assertEqual(Species.get_species_name(common_name), species_name)
-        self.assertEqual(Species.get_common_name(species_name), common_name)
-        self.assertEqual(Species.get_common_name("Bushbaby"), common_name)
-        self.assertEqual(
-            Species.get_ensembl_db_prefix("Bushbaby"),
-            "otolemur_garnettii",
-        )
-        self.assertEqual(
-            Species.get_ensembl_db_prefix(species_name),
-            "otolemur_garnettii",
-        )
-        self.assertEqual(
-            Species.get_ensembl_db_prefix(common_name),
-            "otolemur_garnettii",
-        )
+def test_get_ensembl_format():
+    """should take common or latin names and return the corresponding
+    ensembl db prefix"""
+    assert Species.get_ensembl_db_prefix("human") == "homo_sapiens"
+    assert Species.get_ensembl_db_prefix("mouse") == "mus_musculus"
+    assert Species.get_ensembl_db_prefix("Mus musculus") == "mus_musculus"
+    assert (
+        Species.get_ensembl_db_prefix("Canis lupus familiaris")
+        == "canis_lupus_familiaris"
+    )
 
-    def test_amend_existing(self):
-        """should correctly amend an existing species"""
-        species_name = "Ochotona princeps"
-        common_name1 = "american pika"
-        common_name2 = "pika"
-        ensembl_pref = "ochotona_princeps"
-        Species.amend_species(species_name, common_name1)
-        self.assertEqual(Species.get_common_name(species_name), common_name1)
-        Species.amend_species(species_name, common_name2)
-        self.assertEqual(Species.get_species_name(common_name2), species_name)
-        self.assertEqual(Species.get_species_name(ensembl_pref), species_name)
-        self.assertEqual(Species.get_common_name(species_name), common_name2)
-        self.assertEqual(Species.get_common_name(ensembl_pref), common_name2)
-        self.assertEqual(Species.get_ensembl_db_prefix(species_name), ensembl_pref)
-        self.assertEqual(Species.get_ensembl_db_prefix(common_name2), ensembl_pref)
 
-    def test_lookup_raises(self):
-        """setting level  to raise should create exceptions"""
-        self.assertRaises(ValueError, Species.get_species_name, "failme", level="raise")
-        self.assertRaises(ValueError, Species.get_common_name, "failme", level="raise")
-        self.assertRaises(ValueError, Species.get_ensembl_db_prefix, "failme")
+def test_add_new_species():
+    """should correctly add a new species/common combination and infer the
+    correct ensembl prefix"""
+    species_name, common_name = "Otolemur garnettii", "Bushbaby"
+    Species.amend_species(species_name, common_name)
+    assert Species.get_species_name(species_name) == species_name
+    assert Species.get_species_name("Bushbaby") == species_name
+    assert Species.get_species_name(common_name) == species_name
+    assert Species.get_common_name(species_name) == common_name
+    assert Species.get_common_name("Bushbaby") == common_name
+    assert Species.get_ensembl_db_prefix("Bushbaby") == "otolemur_garnettii"
+    assert Species.get_ensembl_db_prefix(species_name) == "otolemur_garnettii"
+    assert Species.get_ensembl_db_prefix(common_name) == "otolemur_garnettii"
 
-    def test_to_table(self):
-        """returns a table object"""
-        table = Species.to_table()
-        self.assertIsInstance(table, Table)
-        self.assertTrue(table.shape[0] > 20)
-        self.assertEqual(table.shape[1], 3)
+
+def test_amend_existing():
+    """should correctly amend an existing species"""
+    species_name = "Ochotona princeps"
+    common_name1 = "american pika"
+    common_name2 = "pika"
+    ensembl_pref = "ochotona_princeps"
+    Species.amend_species(species_name, common_name1)
+    assert Species.get_common_name(species_name) == common_name1
+    Species.amend_species(species_name, common_name2)
+    assert Species.get_species_name(common_name2) == species_name
+    assert Species.get_species_name(ensembl_pref) == species_name
+    assert Species.get_common_name(species_name) == common_name2
+    assert Species.get_common_name(ensembl_pref) == common_name2
+    assert Species.get_ensembl_db_prefix(species_name) == ensembl_pref
+    assert Species.get_ensembl_db_prefix(common_name2) == ensembl_pref
+
+
+def test_lookup_raises():
+    """setting level  to raise should create exceptions"""
+    with pytest.raises(ValueError):
+        Species.get_species_name("failme", level="raise")
+    with pytest.raises(ValueError):
+        Species.get_common_name("failme", level="raise")
+    with pytest.raises(ValueError):
+        Species.get_ensembl_db_prefix("failme")
+
+
+def test_to_table():
+    """returns a table object"""
+    table = Species.to_table()
+    assert isinstance(table, Table)
+    assert table.shape[0] > 20
+    assert table.shape[1] == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Refactor species tests to pytest style assertions and update an optional string type annotation to modern union syntax

Enhancements:
- Refactor test_species tests to use pytest style with bare asserts and pytest.raises
- Simplify StrOrNone type annotation in _species module to use PEP 604 union syntax

Tests:
- Migrate all species tests from unittest.TestCase to top-level pytest functions with assert statements