### PR TITLE
MAINT: improve error tracking in alignments cli

### DIFF
--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -401,7 +401,7 @@ class construct_alignment:  # noqa: N801
             shadow=self._shadow,
             mask_ref=self._ref_only,
         ):
-            aln.info.source = segment.source
+            aln.source = segment.source
             results.append(aln)
 
         return results

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -521,7 +521,7 @@ def alignments(
     mask_shadow: list[str] | None,
     mask_ref: bool,
     ref_coords: list[eti_genome.genome_segment],
-    limit: int,
+    limit: int | None,
     force_overwrite: bool,
     verbose: bool,
 ) -> None:
@@ -529,6 +529,10 @@ def alignments(
     from rich import progress
 
     from ensembl_tui import _align as eti_align
+
+    LOGGER = CachingLogger()
+    LOGGER.log_args()
+    LOGGER.log_versions(["cogent3", "cogent3_h5seqs", "numpy", "duckdb"])
 
     if mask and mask_shadow:
         eti_util.print_colour(
@@ -546,6 +550,8 @@ def alignments(
 
     if force_overwrite:
         shutil.rmtree(outdir, ignore_errors=True)
+
+    LOGGER.log_file_path = outdir / f"alignments-{ref}.log"
 
     config = eti_config.read_installed_cfg(installed)
     align_db = eti_align.load_aligndb(config=config, align_name=align_name)
@@ -600,6 +606,9 @@ def alignments(
             limit=limit,
             stableids=stableids,
         )
+    if limit:
+        locations = locations[:limit]
+
     mask = mask_shadow or mask
     shadow = bool(mask_shadow)
     maker = eti_align.construct_alignment(
@@ -630,9 +639,11 @@ def alignments(
             if not alignments:
                 if verbose:
                     eti_util.print_colour(str(alignments), colour="red")
+                if not isinstance(alignments, list):
+                    writer(alignments)
                 continue
 
-            input_source = alignments[0].info.source
+            input_source = alignments[0].source
             if len(alignments) == 1:
                 writer(alignments[0], identifier=input_source)
                 continue
@@ -644,6 +655,11 @@ def alignments(
                     continue
                 identifier = f"{input_source}-{i}"
                 writer(aln, identifier=identifier)
+
+    log_file_path = pathlib.Path(LOGGER.log_file_path)
+    LOGGER.shutdown()
+    output.write_log(unique_id=log_file_path.name, data=log_file_path.read_text())
+    log_file_path.unlink()
 
     eti_util.print_colour(text="Done!", colour="green")
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -530,9 +530,9 @@ def alignments(
 
     from ensembl_tui import _align as eti_align
 
-    LOGGER = CachingLogger()
-    LOGGER.log_args()
-    LOGGER.log_versions(["cogent3", "cogent3_h5seqs", "numpy", "duckdb"])
+    logger = CachingLogger()
+    logger.log_args()
+    logger.log_versions(["cogent3", "cogent3_h5seqs", "numpy", "duckdb"])
 
     if mask and mask_shadow:
         eti_util.print_colour(
@@ -551,7 +551,7 @@ def alignments(
     if force_overwrite:
         shutil.rmtree(outdir, ignore_errors=True)
 
-    LOGGER.log_file_path = outdir / f"alignments-{ref}.log"
+    logger.log_file_path = outdir / f"alignments-{ref}.log"
 
     config = eti_config.read_installed_cfg(installed)
     align_db = eti_align.load_aligndb(config=config, align_name=align_name)
@@ -656,10 +656,10 @@ def alignments(
                 identifier = f"{input_source}-{i}"
                 writer(aln, identifier=identifier)
 
-    log_file_path = pathlib.Path(LOGGER.log_file_path)
-    LOGGER.shutdown()
+    log_file_path = pathlib.Path(logger.log_file_path)
+    logger.shutdown()
     output.write_log(unique_id=log_file_path.name, data=log_file_path.read_text())
-    log_file_path.unlink()
+    log_file_path.unlink(missing_ok=True)
 
     eti_util.print_colour(text="Done!", colour="green")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,6 +479,10 @@ def test_alignments_coord_names(apes_install_path, tmp_dir, coord_name):
     assert r.exit_code == 0, r.output
     dstore = cogent3.open_data_store(outdir, suffix="fa", mode="r")
     assert len(dstore.completed)
+    logged = dstore.logs[0].read()
+    assert isinstance(logged, str)
+    # check the version of one dependency is present
+    assert "version : cogent3_h5seqs" in logged
 
 
 @pytest.fixture


### PR DESCRIPTION
[FIXED] limit argument to alignments command now works

[NEW] now record errors as not completed output for alignments

[NEW] now store logfile in output from alignments

## Summary by Sourcery

Improve error tracking and logging in the alignments CLI by fixing the limit argument, integrating a CachingLogger to capture args and versions, recording failures as non-completed output, storing the logfile in the result store, and updating the alignment source attribute.

New Features:
- Introduce CachingLogger to capture CLI arguments and dependency versions for the alignments command
- Record errors and incomplete alignments output and publish the logfile in the output data store

Bug Fixes:
- Fix the limit parameter to correctly restrict the number of processed alignment locations

Enhancements:
- Update alignment source assignment from aln.info.source to aln.source to match the Alignment model

Tests:
- Add tests to ensure the generated logfile is written to the output store and contains dependency version information