### PR TITLE
Minor changes

### DIFF
--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -367,6 +367,8 @@ def read_config(
                 site_map=site_map,
                 tree_fname=tree_name,
             )
+            if tree is None:
+                continue
             sp = eti_species.species_from_ensembl_tree(tree)
             species_dbs |= sp
 

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -58,7 +58,7 @@ def get_core_db_dirnames(config: eti_config.Config) -> dict[str, str]:
         if "_core_" not in db_name:
             continue
         db = eti_name.EnsemblDbName(db_name.rsplit("/", maxsplit=1)[1])
-        if db.species in config.species_dbs and db.db_type == "core":
+        if db.prefix in config.species_dbs and db.db_type == "core":
             selected_species[db.prefix] = db_name
     return selected_species
 

--- a/src/ensembl_tui/_name.py
+++ b/src/ensembl_tui/_name.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-import typing_extensions
-
-from ._species import Species
-
 _release = re.compile(r"\d+")
 
 _db_types = (
@@ -52,7 +48,7 @@ def get_db_prefix(name: str) -> str:
 
 class EnsemblDbName:
     """container for a db name, inferring different attributes from the name,
-    such as species, version, build"""
+    such as db prefix, version, build"""
 
     def __init__(self, db_name: str) -> None:
         """db_name: and Emsembl database name"""
@@ -74,8 +70,6 @@ class EnsemblDbName:
             self.build = build[1]
             self.general_release = build[0]
 
-        self.species = Species.get_species_name(self.prefix)
-
     def __repr__(self) -> str:
         build = f"; build='{self.build}'" if self.build is not None else ""
         return f"db(prefix='{self.prefix}'; type='{self.db_type}'; release='{self.release}'{build})"
@@ -83,17 +77,17 @@ class EnsemblDbName:
     def __str__(self) -> str:
         return self.name
 
-    def __lt__(self, other: typing_extensions.Self | str) -> bool:
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.name < other.name
-        return self.name < other
+        return self.name < other if isinstance(other, str) else NotImplemented
 
-    def __eq__(self, other: typing_extensions.Self) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.name == other.name
         return self.name == other
 
-    def __ne__(self, other: typing_extensions.Self | str) -> bool:
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.name != other.name
         return self.name != other

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -38,9 +38,10 @@ def test_species_with_three_words_name():
     assert n.prefix == "mustela_putorius_furo"
     assert n.db_type == "core"
     assert n.build == "1"
-    assert n.species == "Mustela putorius furo"
     n = EnsemblDbName("canis_lupus_familiaris_core_102_31")
-    assert n.species == "Canis lupus familiaris"
+    assert n.prefix == "canis_lupus_familiaris"
+    assert n.db_type == "core"
+    assert n.build == "31"
 
 
 def test_ensemblgenomes_names():


### PR DESCRIPTION
## Summary by Sourcery

Remove species inference from EnsemblDbName, refactor comparison dunder methods, update configuration to skip missing trees, adjust download logic to use db.prefix, and update tests accordingly.

Bug Fixes:
- Skip None trees in read_config loop to avoid processing errors
- Filter core database selection by db.prefix instead of removed species attribute

Enhancements:
- Drop Species import and species attribute from EnsemblDbName and update its docstring
- Refactor comparison methods (__lt__, __eq__, __ne__) to accept object type and return NotImplemented for unsupported comparisons

Tests:
- Remove species assertions in name tests and add checks for prefix, db_type, and build