### PR TITLE
ENH: provide support for getting Ensembl species information

### DIFF
--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -12,9 +12,45 @@ from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
 
+def just_one_species(
+    *, data: list[str] | str, species_map: eti_species.SpeciesNameMap
+) -> str:
+    if data is None:
+        eti_util.print_colour(
+            text="ERROR: no species  provided",
+            colour="red",
+        )
+        sys.exit(1)
+
+    species: list[str] = [data] if isinstance(data, str) else data
+    if len(species) > 1:
+        eti_util.print_colour(
+            text=f"ERROR: one species at a time, not {species!r}",
+            colour="red",
+        )
+        sys.exit(1)
+
+    selected_species = species[0]
+    if selected_species not in species_map:
+        eti_util.print_colour(
+            text=f"ERROR: invalid species name {selected_species!r}", colour="red"
+        )
+        sys.exit(1)
+    return selected_species
+
+
+def species_map_from_tsv(
+    ctx: "Context",  # noqa: ARG001
+    param: "Option",  # noqa: ARG001
+    tsv_file: str | None,
+) -> eti_species.SpeciesNameMap:
+    """returns a SpeciesNameMap from a tsv file"""
+    return eti_species.make_species_map(tsv_file)
+
+
 def stableids_from_tsv(
-    ctx: "Context",
-    param: "Option",
+    ctx: "Context",  # noqa: ARG001
+    param: "Option",  # noqa: ARG001
     tsv_file: pathlib.Path,
 ) -> list[str] | None:
     if not tsv_file:
@@ -75,21 +111,7 @@ def species_names_from_csv(
 ) -> list[str] | None:
     """returns species names"""
     species_names = values_from_csv_or_file(ctx, param, species)
-    species_names = None if species_names == [""] else species_names
-    if species_names is None:
-        return None
-
-    db_names = []
-    for name in species_names:
-        try:
-            db_name = eti_species.Species.get_ensembl_db_prefix(name)
-        except ValueError:
-            eti_util.print_colour(text=f"ERROR: unknown species {name!r}", colour="red")
-            sys.exit(1)
-
-        db_names.append(db_name)
-
-    return db_names
+    return None if species_names == [""] else species_names
 
 
 def genome_coords_from_tsv(
@@ -152,7 +174,7 @@ def genome_coords_from_tsv(
 
     return [
         eti_genome.genome_segment(
-            species=str(eti_species.Species.get_ensembl_db_prefix(sp)),
+            species=sp,
             seqid=str(seqid),
             start=int(start),
             stop=int(stop),

--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -7,6 +7,7 @@ from cogent3 import load_table
 
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
+from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
@@ -275,4 +276,10 @@ nprocs = click.option(
     default=1,
     help="Number of procs to use.",
     show_default=True,
+)
+site = click.option(
+    "--site",
+    default="main",
+    type=click.Choice(eti_site_map.get_site_map_names(), case_sensitive=False),
+    help="Ensembl site to use for species list.",
 )

--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -283,3 +283,10 @@ site = click.option(
     type=click.Choice(eti_site_map.get_site_map_names(), case_sensitive=False),
     help="Ensembl site to use for species list.",
 )
+species_map = click.option(
+    "-sm",
+    "--species_map",
+    default="main",
+    callback=species_map_from_tsv,
+    help="Tsv file with species names, abbreviations etc..",
+)

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -307,7 +307,9 @@ def _standardise_path(
 
 
 def read_config(
+    *,
     config_path: pathlib.Path,
+    species_map: eti_species.SpeciesNameMap | None = None,
     root_dir: pathlib.Path | None = None,
 ) -> Config:
     """returns ensembl release, local path, and db specifics from the provided
@@ -352,8 +354,8 @@ def read_config(
         dbs = [db.strip() for db in get_option(section, "db").split(",")]
 
         # handle synonyms
-        species = eti_species.Species.get_species_name(section, level="raise")
-        species_dbs[species] = dbs
+        species_name = species_map.get_species_name(section, level="raise")
+        species_dbs[species_name] = dbs
 
     # we also want homologies if we want alignments
     homologies = homologies or bool(align_names)
@@ -369,7 +371,8 @@ def read_config(
             )
             if tree is None:
                 continue
-            sp = eti_species.species_from_ensembl_tree(tree)
+
+            sp = eti_species.species_from_ensembl_tree(tree, species_map=species_map)
             species_dbs |= sp
 
     return Config(

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -22,6 +22,7 @@ _HOMOLOGIES_NAME: str = "homologies"
 _GENOMES_NAME: str = "genomes"
 
 _VERSION_SECTION = "software versions"
+_SPECIES_MAP_SECTION = "species_map"
 
 
 def make_relative_to(
@@ -50,6 +51,7 @@ class Config:
     align_names: Sequence[str]
     tree_names: Sequence[str]
     homologies: bool
+    species_map: eti_species.SpeciesNameMap
 
     def __post_init__(self) -> None:
         self.staging_path = pathlib.Path(self.staging_path)
@@ -71,7 +73,7 @@ class Config:
     @property
     def db_names(self) -> Generator[str, None, None]:
         for species in self.species_dbs:
-            yield eti_species.Species.get_ensembl_db_prefix(species)
+            yield self.species_map.get_ensembl_db_prefix(species)
 
     @property
     def staging_genomes(self) -> pathlib.Path:
@@ -97,7 +99,7 @@ class Config:
     def install_aligns(self) -> pathlib.Path:
         return self.install_path / _COMPARA_NAME / _ALIGNS_NAME
 
-    def to_dict(self, relative_paths: bool = True) -> dict[str, str]:
+    def to_dict(self, relative_paths: bool = True) -> dict[str, dict[str, str]]:
         """returns cfg as a dict"""
         if not self.db_names:
             msg = "no db names"
@@ -150,6 +152,14 @@ class Config:
             parser.add_section(section)
             for option, val in settings.items():
                 parser.set(section, option=option, value=val)
+
+        # add the species map section (maps between db name, common name,
+        # abbrev etc..)
+        parser.add_section(_SPECIES_MAP_SECTION)
+        subset = self.species_map.get_subset(list(self.species_dbs))
+        for label, value in subset.for_storage().items():
+            parser.set(_SPECIES_MAP_SECTION, option=label, value=value)
+
         self.staging_path.mkdir(parents=True, exist_ok=True)
         with (self.staging_path / DOWNLOADED_CONFIG_NAME).open(mode="w") as out:
             parser.write(out, space_around_delimiters=True)
@@ -160,6 +170,7 @@ class InstalledConfig:
     release: str
     install_path: pathlib.Path
     software_versions: dict[str, str]
+    species_map: eti_species.SpeciesNameMap
 
     def __hash__(self) -> int:
         return id(self)
@@ -184,13 +195,13 @@ class InstalledConfig:
         return self.install_path / _GENOMES_NAME
 
     def installed_genome(self, species: str) -> pathlib.Path:
-        db_name = eti_species.Species.get_ensembl_db_prefix(species)
+        db_name = self.species_map.get_ensembl_db_prefix(species, level="raise")
         return self.genomes_path / db_name
 
     def list_genomes(self) -> list[str]:
         """returns list of installed genomes"""
         return [
-            p.name for p in self.genomes_path.glob("*") if p.name in eti_species.Species
+            p.name for p in self.genomes_path.glob("*") if p.name in self.species_map
         ]
 
     def path_to_alignment(self, pattern: str, suffix: str) -> pathlib.Path | None:
@@ -269,6 +280,15 @@ def write_installed_cfg(config: Config) -> eti_util.PathType:
     for pkg, vers in deps.items():
         parser.set(_VERSION_SECTION, pkg, vers)
 
+    # add the species map section (maps between db name, common name, abbrev etc..)
+    parser.add_section(_SPECIES_MAP_SECTION)
+    subset = config.species_map.get_subset(list(config.species_dbs))
+    store_map = subset.for_storage()
+    parser.set(_SPECIES_MAP_SECTION, "header", store_map.pop("header"))
+    # now add the species, value the remainder comma separated
+    for genome, value in store_map.items():
+        parser.set(_SPECIES_MAP_SECTION, genome, value)
+
     outpath = config.install_path / INSTALLED_CONFIG_NAME
     outpath.parent.mkdir(parents=True, exist_ok=True)
     with outpath.open(mode="w") as out:
@@ -293,8 +313,18 @@ def read_installed_cfg(path: eti_util.PathType) -> InstalledConfig:
         software_versions = dict(parser.items(_VERSION_SECTION))
     else:
         software_versions = {}
+
+    if parser.has_section("species_map"):
+        map_data = dict(parser.items("species_map"))
+        sp_map = eti_species.SpeciesNameMap.from_storage(map_data)
+    else:
+        sp_map = eti_species.make_species_map(species_path=None)
+
     return InstalledConfig(
-        release=release, install_path=path.parent, software_versions=software_versions
+        release=release,
+        install_path=path.parent,
+        software_versions=software_versions,
+        species_map=sp_map,
     )
 
 
@@ -306,6 +336,18 @@ def _standardise_path(
     return path if path.is_absolute() else (config_path / path).resolve()
 
 
+def _pop_section(
+    config: configparser.ConfigParser, section_name: str
+) -> dict[str, str]:
+    """Pop a section from config, returning its items as a dict"""
+    # Get all items from the section
+    data = dict(config.items(section_name))
+    # Remove the section
+    config.remove_section(section_name)
+
+    return data
+
+
 def read_config(
     *,
     config_path: pathlib.Path,
@@ -314,7 +356,7 @@ def read_config(
 ) -> Config:
     """returns ensembl release, local path, and db specifics from the provided
     config path"""
-    from ensembl_tui._download import download_ensembl_tree
+    from ensembl_tui._download import download_ensembl_tree, get_species_for_alignments
 
     if not config_path.exists():
         eti_util.print_colour(f"File not found {config_path.resolve()!s}", colour="red")
@@ -325,55 +367,86 @@ def read_config(
     with config_path.expanduser().open() as f:
         parser.read_file(f)
 
+    if parser.has_section(_SPECIES_MAP_SECTION):
+        # species map embedded in config takes precedence
+        map_data = _pop_section(parser, _SPECIES_MAP_SECTION)
+        sp_map = eti_species.SpeciesNameMap.from_storage(map_data)
+    elif species_map is None:
+        sp_map = eti_species.make_species_map(species_path=None)
+    else:
+        sp_map = species_map
+
     if root_dir is None:
         root_dir = config_path.parent
 
-    release = parser.get("release", "release")
-    host = parser.get("remote path", "host")
+    release = _pop_section(parser, "release")["release"]
+    host = _pop_section(parser, "remote path")["host"]
     site_map = eti_site_map.get_site_map(host)
     # paths
-    staging_path = _standardise_path(parser.get("local path", "staging_path"), root_dir)
-    install_path = _standardise_path(parser.get("local path", "install_path"), root_dir)
+    paths = _pop_section(parser, "local path")
+    staging_path = _standardise_path(paths["staging_path"], root_dir)
+    install_path = _standardise_path(paths["install_path"], root_dir)
 
     homologies = parser.has_option("compara", "homologies")
-    species_dbs = {}
-    get_option = parser.get
     align_names = []
     tree_names = []
+    if parser.has_section("compara"):
+        compara = _pop_section(parser, "compara")
+        align_names = (
+            [n.strip() for n in compara["align_names"].split(",")]
+            if "align_names" in compara
+            else []
+        )
+        tree_names = (
+            [n.strip() for n in compara["tree_names"].split(",")]
+            if "tree_names" in compara
+            else []
+        )
+
+    species_dbs = {}
     for section in parser.sections():
-        if section in ("release", "remote path", "local path"):
-            continue
-
-        if section == "compara":
-            value = get_option(section, "align_names", fallback=None)
-            align_names = [] if value is None else [n.strip() for n in value.split(",")]
-            value = get_option(section, "tree_names", fallback=None)
-            tree_names = [] if value is None else [n.strip() for n in value.split(",")]
-            continue
-
-        dbs = [db.strip() for db in get_option(section, "db").split(",")]
-
+        sec = _pop_section(parser, section)
+        dbs = [db.strip() for db in sec["db"].split(",")]
         # handle synonyms
-        species_name = species_map.get_species_name(section, level="raise")
+        species_name = sp_map.get_ensembl_db_prefix(section, level="raise")
         species_dbs[species_name] = dbs
 
     # we also want homologies if we want alignments
     homologies = homologies or bool(align_names)
 
-    if tree_names:
-        # add all species in the tree to species_dbs
-        for tree_name in tree_names:
-            tree = download_ensembl_tree(
-                host=host,
-                release=release,
-                site_map=site_map,
-                tree_fname=tree_name,
-            )
-            if tree is None:
-                continue
+    if not species_dbs and (align_names or tree_names):
+        found = set()
+        if tree_names:
+            # add all species in the tree to species_dbs
+            for tree_name in tree_names:
+                tree = download_ensembl_tree(
+                    host=host,
+                    release=release,
+                    site_map=site_map,
+                    tree_fname=tree_name,
+                )
+                if tree is None:
+                    continue
 
-            sp = eti_species.species_from_ensembl_tree(tree, species_map=species_map)
-            species_dbs |= sp
+                sp = set(
+                    eti_species.species_from_ensembl_tree(tree, species_map=sp_map)
+                )
+                found |= sp
+
+        if align_names:
+            # add all species in the alignments to species_dbs
+            sp = set(
+                get_species_for_alignments(
+                    host=host,
+                    release=release,
+                    site_map=site_map,
+                    align_names=align_names,
+                    species_map=sp_map,
+                )
+            )
+            found |= sp
+
+        species_dbs |= {n: ["core"] for n in found}
 
     return Config(
         host=host,
@@ -384,4 +457,5 @@ def read_config(
         align_names=align_names,
         tree_names=tree_names,
         homologies=homologies,
+        species_map=sp_map,
     )

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -61,15 +61,6 @@ class Config:
     def staging_template_path(self) -> pathlib.Path:
         return self.staging_genomes / "coredb_templates"
 
-    def update_species(self, species: dict[str, list[str]]) -> None:
-        if not species:
-            return
-        for k in species:
-            if k not in eti_species.Species:
-                msg = f"Unknown species {k=!r}"
-                raise ValueError(msg)
-        self.species_dbs |= species
-
     @property
     def db_names(self) -> Generator[str, None, None]:
         for species in self.species_dbs:

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -389,7 +389,12 @@ def get_species_for_alignments(
             tree_fname=pathlib.Path(tree_path).name,
         )
         # dict structure is {common name: db prefix}, just use common name
-        species |= {n: ["core"] for n in eti_species.species_from_ensembl_tree(tree)}
+        species |= {
+            n: ["core"]
+            for n in eti_species.species_from_ensembl_tree(
+                tree, species_map=species_map
+            )
+        }
     return species
 
 

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -1,3 +1,4 @@
+import io
 import pathlib
 import re
 import shutil
@@ -16,6 +17,7 @@ from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
 if typing.TYPE_CHECKING:
+    from cogent3.core.table import Table
     from cogent3.core.tree import PhyloNode
 
 DEFAULT_CFG = eti_util.get_resource_path("sample.cfg")
@@ -389,3 +391,28 @@ def get_species_for_alignments(
         # dict structure is {common name: db prefix}, just use common name
         species |= {n: ["core"] for n in eti_species.species_from_ensembl_tree(tree)}
     return species
+
+
+def download_species_table(
+    *,
+    site_map: eti_site_map.SiteMap,
+) -> "Table":
+    """downloads the species file for the given Ensembl division"""
+    remote = f"{site_map.remote_path}/current/{site_map.species_file_name}"
+    ftp = eti_ftp.configured_ftp(host=site_map.site)
+    buff = io.BytesIO()
+    ftp.retrbinary(f"RETR {remote}", buff.write)
+    buff.seek(0)
+    data = buff.getvalue().decode("utf-8").splitlines()
+    header = data.pop(0).split("\t")
+    header[0] = header[0].lstrip("#")
+    # the file is tab delimited but does not have a consistent number of columns
+    num_col = len(header)
+    rows = [row.split("\t")[:num_col] for row in data]
+    table = cogent3.make_table(header=header, data=rows)
+    abbrevs = eti_species.make_unique_abbrevs(table.columns["species"])
+    table = table.with_new_column("abbrev", lambda x: abbrevs[x], columns=["species"])
+    old = ["name", "species", "core_db"]
+    table = table.with_new_header(old, ["common_name", "genome_name", "db_prefix"])
+    old = ["abbrev", *old]
+    return table.get_columns(["abbrev"] + [c for c in table.header if c not in old])

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -347,8 +347,10 @@ def download_ensembl_tree(
     site_map: eti_site_map.SiteMap,
     release: str,
     tree_fname: str,
-) -> "PhyloNode":
+) -> typing.Optional["PhyloNode"]:
     """loads a tree from Ensembl"""
+    if site_map.trees_path is None:
+        return None
     url = f"https://{host}/{site_map.remote_path}/release-{release}/{site_map.trees_path}/{tree_fname}"
     return cogent3.load_tree(url)
 
@@ -360,6 +362,9 @@ def get_ensembl_trees(
     site_map: eti_site_map.SiteMap,
 ) -> list[str]:
     """returns trees from ensembl compara"""
+    if site_map.trees_path is None:
+        return []
+
     path = f"{site_map.remote_path}/release-{release}/{site_map.trees_path}"
     return list(
         eti_ftp.listdir(host=host, path=path, pattern=lambda x: x.endswith(".nh")),
@@ -379,6 +384,9 @@ def get_species_for_alignments(
         host=host,
         release=release,
     )
+    if not ensembl_trees:
+        return {}
+
     aligns_trees = eti_util.trees_for_aligns(align_names, ensembl_trees)
     species = {}
     for tree_path in aligns_trees.values():
@@ -388,6 +396,8 @@ def get_species_for_alignments(
             release=release,
             tree_fname=pathlib.Path(tree_path).name,
         )
+        if tree is None:
+            continue
         # dict structure is {common name: db prefix}, just use common name
         species |= {
             n: ["core"]

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -161,7 +161,7 @@ def download_species(
 
     patterns = {"fasta": valid_seq_file, "gff3": valid_gff3_file(config.release)}
     for key in config.species_dbs:
-        db_prefix = eti_species.Species.get_ensembl_db_prefix(key)
+        db_prefix = config.species_map.get_ensembl_db_prefix(key)
         local_root = config.staging_genomes / db_prefix
         local_root.mkdir(parents=True, exist_ok=True)
         # getting genome sequences
@@ -377,6 +377,7 @@ def get_species_for_alignments(
     release: str,
     align_names: typing.Iterable[str],
     site_map: eti_site_map.SiteMap,
+    species_map: eti_species.SpeciesNameMap,
 ) -> dict[str, list[str]]:
     """return the species for the indicated alignments"""
     ensembl_trees = get_ensembl_trees(

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -262,6 +262,7 @@ def get_gene_table_for_species(
 def get_species_gene_summary(
     *,
     annot_db: eti_annots.Annotations,
+    species_map: eti_species.SpeciesNameMap,
     species: str | None = None,
 ) -> Table:
     """
@@ -271,6 +272,8 @@ def get_species_gene_summary(
     ----------
     annot_db
         feature db
+    species_map
+        map of common, latin and ensembl db names
     species
         species name, overrides inference from annot_db.source
     """
@@ -278,7 +281,7 @@ def get_species_gene_summary(
     species = species or annot_db.source.parent.name
     counts = annot_db.biotypes.count_distinct()
     try:
-        common_name = eti_species.Species.get_common_name(species)
+        common_name = species_map.get_species_name(species)
     except ValueError:
         common_name = species
 
@@ -290,6 +293,7 @@ def get_species_gene_summary(
 def get_species_repeat_summary(
     *,
     annot_db: eti_annots.Annotations,
+    species_map: eti_species.SpeciesNameMap,
     species: str | None = None,
 ) -> Table:
     """
@@ -299,6 +303,8 @@ def get_species_repeat_summary(
     ----------
     annot_db
         feature db
+    species_map
+        map of common, latin and ensembl db names
     species
         species name, overrides inference from annot_db.source
     """
@@ -306,7 +312,7 @@ def get_species_repeat_summary(
     species = species or annot_db.source.parent.name
     counts = annot_db.repeats.count_distinct(repeat_class=True, repeat_type=True)
     try:
-        common_name = eti_species.Species.get_common_name(species)
+        common_name = species_map.get_species_name(species)
     except ValueError:
         common_name = species
 

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -57,7 +57,7 @@ class fasta_to_hdf5:  # noqa: N801
             "species",
             # we have to coerce the species name from a case insensitive string
             # to a standard python string
-            str(eti_species.Species.get_species_name(db_name)),
+            str(self.config.species_map.get_genome_name(db_name)),
             force=True,
         )
         src_dir = src_dir / "fasta"

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -7,7 +7,6 @@ from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _ingest_align as ingest_aln
 from ensembl_tui import _ingest_annotation as eti_db_ingest
 from ensembl_tui import _ingest_homology as homology_ingest
-from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
 
@@ -58,8 +57,6 @@ def local_install_genomes(
         if progress is not None:
             progress.update(write_features, description=msg, advance=1)
 
-    species_table = eti_species.Species.to_table()
-    species_table.write(config.install_genomes / eti_species.SPECIES_NAME)
     if verbose:
         eti_util.print_colour("\nFinished installing features", "yellow")
 

--- a/src/ensembl_tui/_name.py
+++ b/src/ensembl_tui/_name.py
@@ -42,6 +42,8 @@ def get_version_from_name(name):
 def get_db_prefix(name: str) -> str:
     """returns the db prefix, typically an organism or `ensembl'"""
     db_type = get_dbtype_from_name(name)
+    if not db_type:
+        return name
     parts = name.split(db_type)[0].split("_")
     return "_".join(parts[:-1])
 
@@ -55,6 +57,9 @@ class EnsemblDbName:
         self.name = db_name
         self.db_type = get_dbtype_from_name(db_name)
         self.prefix = get_db_prefix(db_name)
+        if " " in self.prefix:
+            msg = f"Invalid db_name {db_name!r}, contains a space"
+            raise ValueError(msg)
 
         release, build = get_version_from_name(db_name)
         self.release = release

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -49,6 +49,7 @@ class SiteMap:
     db_host: str
     db_port: int
     remote_path: str
+    species_file_name: str
     _seqs_path: str = "fasta"
     _annotations_path: str = "mysql"
     _alignments_path: str | None = None
@@ -79,6 +80,8 @@ class SiteMap:
 
 
 @extend_docstring_from(SiteMap)
+@register_ensembl_site_map("main")
+@register_ensembl_site_map("vertebrates")
 @register_ensembl_site_map("ftp.ensembl.org")
 def ensembl_main_sitemap() -> SiteMap:
     """the main Ensembl site map"""
@@ -90,12 +93,14 @@ def ensembl_main_sitemap() -> SiteMap:
         db_host="ensembldb.ensembl.org",
         db_port=3306,
         remote_path="pub",
+        species_file_name="species_EnsemblVertebrates.txt",
     )
 
 
+@register_ensembl_site_map("metazoa")
 @register_ensembl_site_map("ftp.ensemblgenomes.org")
 def ensembl_metazoa_sitemap() -> SiteMap:
-    """the main Ensembl site map"""
+    """the metazoa Ensembl site map"""
     return SiteMap(
         site="ftp.ensemblgenomes.org",
         _alignments_path=None,
@@ -104,6 +109,7 @@ def ensembl_metazoa_sitemap() -> SiteMap:
         db_host="mysql-eg-publicsql.ebi.ac.uk",
         db_port=4157,
         remote_path="pub/metazoa",
+        species_file_name="species_EnsemblMetazoa.txt",
     )
 
 
@@ -122,3 +128,8 @@ def ensembl_metazoa_sitemap() -> SiteMap:
 def get_site_map(domain: str) -> SiteMap:
     """returns a site map instance"""
     return _ensembl_site_map[domain]()
+
+
+def get_site_map_names() -> list[str]:
+    """returns the registered site map names"""
+    return list(_ensembl_site_map)

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -1,5 +1,5 @@
-import os
 import pathlib
+import re
 import typing
 
 from cogent3 import load_table, make_table
@@ -7,37 +7,85 @@ from cogent3.core.tree import PhyloNode
 
 from ensembl_tui import _util as eti_util
 
+if typing.TYPE_CHECKING:
+    from cogent3.core.table import Table
+
 SPECIES_NAME = "species.tsv"
 StrOrNone = str | None
 
+# essential table columns
+TABLE_COLUMNS = ["abbrev", "common_name", "genome_name", "db_prefix"]
 
-def load_species(species_path: eti_util.PathType) -> list[list[str]]:
-    """returns [[latin_name, common_name, stableid prefix],..] from species_path
+# some species name records have an accession identifier, which contains digits
+_accession = re.compile(r"\d")
+
+
+def load_species(species_path: eti_util.PathType | None) -> "Table":
+    """returns Table from species_path
 
     if species_path does not exist, defaults to default one"""
-    if not os.path.exists(species_path):
-        species_path = eti_util.get_resource_path("species.tsv")
+    if species_path is None or not pathlib.Path(species_path).exists():
+        species_path = eti_util.get_resource_path(SPECIES_NAME)
 
-    table = load_table(species_path)
-    return table.to_list()
+    return load_table(species_path)
 
 
-_species_common_map = load_species(os.path.join(eti_util.ENSEMBLDBRC, SPECIES_NAME))
+def make_species_map(species_path: eti_util.PathType | None) -> "SpeciesNameMap":
+    """returns a SpeciesNameMap from the default species table"""
+    species_table = load_species(species_path)
+    return SpeciesNameMap.from_table(species_table)
+
+
+def _genome_name_to_species_name(genome_name: str) -> str:
+    """convert an ensembl db prefix to a species name"""
+    name = genome_name.replace("_", " ").capitalize().split()
+    return " ".join(p for p in name if not _accession.search(p))
+
+
+def _latin_to_abbrev(genome_to_abrv: dict[str, str], latin_name: str) -> str | None:
+    """convert a latin name to a abbreviation"""
+    if " " not in latin_name:
+        return None
+
+    latin_name = latin_name.replace(" ", "_")
+    found = []
+    for genome_name, abrv in genome_to_abrv.items():
+        if genome_name == latin_name:
+            return abrv
+        if genome_name.startswith(latin_name):
+            found.append(abrv)
+    if len(found) == 1:
+        return found[0]
+
+    msg = f"matches to {latin_name!r} {found} != 1"
+    raise ValueError(msg)
 
 
 class SpeciesNameMap:
     """mapping between common names and latin names"""
 
-    def __init__(self, species_common=_species_common_map):
-        """provides latin name:common name mappings"""
-        self._species_common = {}
-        self._common_species = {}
-        self._species_ensembl = {}
-        self._ensembl_species = {}
-        self._stableid_species = {}  # stable id prefix to species map
-        for names in species_common:
-            names = list(map(eti_util.CaseInsensitiveString, names))
-            self.amend_species(*names)
+    def __init__(
+        self,
+        *,
+        abbrev_common: dict[str, str],
+        abbrev_genome: dict[str, str],
+        abbrev_db: dict[str, str],
+    ) -> None:
+        """provides mappings between abbrev:genome:db_prefix:common name"""
+        # all queries will go via abbreviations
+        # delete below
+        self._db_prefix_to_common = {
+            db: abbrev_common[abrv] for abrv, db in abbrev_db.items()
+        }
+        # common name mappings
+        self._abrv_to_common = abbrev_common
+        self._common_to_abrv = {c: a for a, c in abbrev_common.items()}
+        # db prefix mappings
+        self._abrv_to_db = abbrev_db
+        self._db_to_abrv = {db: abrv for abrv, db in abbrev_db.items()}
+        # species name mappings
+        self._abrv_to_genome = abbrev_genome
+        self._genome_to_abrv = {genome: abrv for abrv, genome in abbrev_genome.items()}
 
     def __str__(self) -> str:
         return str(self.to_table())
@@ -45,14 +93,18 @@ class SpeciesNameMap:
     def __repr__(self) -> str:
         return repr(self.to_table())
 
-    def __contains__(self, item) -> bool:
-        item = eti_util.CaseInsensitiveString(item)
+    def __contains__(self, item: str) -> bool:
+        item = item.lower()
+        if " " in item:
+            return _genome_name_to_species_name(item) is not None
+
         return any(
             item in attr
             for attr in (
-                self._species_common,
-                self._common_species,
-                self._ensembl_species,
+                self._abrv_to_db,
+                self._db_to_abrv,
+                self._common_to_abrv,
+                self._genome_to_abrv,
             )
         )
 
@@ -60,144 +112,105 @@ class SpeciesNameMap:
         table = self.to_table()
         return table._repr_html_()
 
-    def get_common_name(self, name: str, level="raise") -> StrOrNone:
-        """returns the common name for the given name (which can be either a
-        species name or the ensembl version)"""
-        name = eti_util.CaseInsensitiveString(name)
-        if name in self._ensembl_species:
-            name = self._ensembl_species[name]
+    def _handle_optional_errors(self, name: str, level: str) -> None:
+        msg = f"Unknown {name!r}"
+        if level == "raise":
+            raise ValueError(msg)
+        if level == "warn":
+            print(f"WARN: {msg}")
 
-        if name in self._species_common:
-            common_name = self._species_common[name]
-        elif name in self._common_species:
-            common_name = name
-        else:
-            common_name = None
-
-        if common_name is None:
-            msg = f"Unknown species name: {name}"
-            if level == "raise":
-                raise ValueError(msg)
-            if level == "warn":
-                print(f"WARN: {msg}")
-
-        return common_name
-
-    def get_species_name(self, name: str, level="ignore") -> StrOrNone:
-        """returns the species name for the given common name"""
-        name = eti_util.CaseInsensitiveString(name)
-        if name in self._species_common:
+    def _get_abbrev_for_name(self, name: str) -> StrOrNone:
+        name = name.lower()
+        if name in self._abrv_to_db:
             return name
 
-        species_name = None
-        level = level.lower().strip()
-        for data in [self._common_species, self._ensembl_species]:
-            if name in data:
-                species_name = data[name]
-        if species_name is None:
-            msg = f"Unknown common name: {name}"
-            if level == "raise":
-                raise ValueError(msg)
-            if level == "warn":
-                print(f"WARN: {msg}")
+        for attr in (self._common_to_abrv, self._db_to_abrv, self._genome_to_abrv):
+            if name in attr:
+                return attr[name]
 
-        return species_name
+        if " " in name and (abrv := _latin_to_abbrev(self._genome_to_abrv, name)):
+            return abrv
 
-    def get_species_names(self) -> typing.Sequence[StrOrNone]:
-        """returns the list of species names"""
-        return sorted(self._species_common.keys())
+        return None
 
-    def get_ensembl_db_prefix(self, name: str) -> str:
-        """returns a string of the species name in the format used by
-        ensembl"""
-        name = eti_util.CaseInsensitiveString(name)
-        if name in self._common_species:
-            name = self._common_species[name]
-        try:
-            species_name = self.get_species_name(name, level="raise")
-        except ValueError as e:
-            if name not in self._species_common:
-                raise ValueError(f"Unknown name {name}") from e
-            species_name = name
+    def get_common_name(
+        self, name: str, level: typing.Literal["ignore", "warn", "raise"] = "raise"
+    ) -> StrOrNone:
+        """returns the common name"""
+        if abrv := self._get_abbrev_for_name(name):
+            return self._abrv_to_common[abrv]
 
-        return str(species_name.lower().replace(" ", "_"))
+        self._handle_optional_errors(name, level)
+        return None
 
-    def get_db_prefix_from_stableid(self, stableid: str) -> str:
-        """returns the db name from a stableid"""
-        prefix = eti_util.get_stableid_prefix(stableid)
-        species = self._stableid_species[prefix]
-        return species.replace(" ", "_").lower()
+    def get_species_name(
+        self, name: str, level: typing.Literal["ignore", "warn", "raise"] = "ignore"
+    ) -> StrOrNone:
+        """returns the latin name"""
+        if abrv := self._get_abbrev_for_name(name):
+            return _genome_name_to_species_name(self._abrv_to_genome[abrv])
 
-    def _purge_species(self, species_name):
-        """removes a species record"""
-        species_name = eti_util.CaseInsensitiveString(species_name)
-        if species_name not in self._species_common:
-            return
-        common_name = self._species_common.pop(species_name)
-        ensembl_name = self._species_ensembl.pop(species_name)
-        self._ensembl_species.pop(ensembl_name)
-        self._common_species.pop(common_name)
+        self._handle_optional_errors(name, level)
+        return None
 
-    def amend_species(self, species_name, common_name, stableid_prefix=None):
-        """add a new species, and common name"""
-        species_name = eti_util.CaseInsensitiveString(species_name)
-        common_name = eti_util.CaseInsensitiveString(common_name)
-        assert "_" not in species_name, "'_' in species_name, not a Latin name?"
-        self._purge_species(species_name)  # remove if existing
-        self._species_common[species_name] = common_name
-        self._common_species[common_name] = species_name
-        ensembl_name = species_name.lower().replace(" ", "_")
-        self._species_ensembl[species_name] = ensembl_name
-        self._ensembl_species[ensembl_name] = species_name
-        if stableid_prefix:
-            # make sure stableid just a string
-            for prefix in stableid_prefix.split(","):
-                self._stableid_species[prefix] = ensembl_name
+    def get_genome_name(
+        self, name: str, level: typing.Literal["ignore", "warn", "raise"] = "ignore"
+    ) -> str | None:
+        """returns the Ensembl genome name"""
+        if abrv := self._get_abbrev_for_name(name):
+            return self._abrv_to_genome[abrv]
 
-    def add_stableid_prefix(
-        self,
-        species_name: str,
-        stableid_prefix: str | eti_util.CaseInsensitiveString,
-    ):
-        self._stableid_species[str(stableid_prefix)] = self.get_species_name(
-            species_name,
-        )
+        self._handle_optional_errors(name, level)
+        return None
 
-    def to_table(self):
+    def get_ensembl_db_prefix(
+        self, name: str, level: typing.Literal["ignore", "warn", "raise"] = "ignore"
+    ) -> str | None:
+        """returns the Ensembl db prefix"""
+        if abrv := self._get_abbrev_for_name(name):
+            return self._abrv_to_db[abrv]
+
+        self._handle_optional_errors(name, level)
+        return None
+
+    def get_abbreviation(self, name: str) -> StrOrNone:
+        """returns the abbreviation for the given name"""
+        return self._get_abbrev_for_name(name)
+
+    def to_table(self) -> "Table":
         """returns cogent3 Table"""
-        rows = []
-        for common in self._common_species:
-            species = self._common_species[common]
-            ensembl = self._species_ensembl[species]
-            # all prefixes for this species
-            stableids = ",".join(
-                [k for k, v in self._stableid_species.items() if v == ensembl],
-            )
-            rows += [[species, common, stableids]]
+        rows = [
+            [abrv, self._abrv_to_common[abrv], self._abrv_to_genome[abrv], db_prefix]
+            for db_prefix, abrv in self._db_to_abrv.items()
+        ]
         return make_table(
-            header=[
-                "Species name",
-                "Common name",
-                "Ensembl stableid Prefix",
-            ],
+            header=TABLE_COLUMNS,
             data=rows,
             space=2,
         ).sorted()
 
-    def update_from_file(self, species_path: pathlib.Path) -> None:
-        """updates instance from tab delimited table at species_path"""
-        table = load_table(species_path)
-        columns = "Species name", "Ensembl stableid Prefix"
-        for sp, prefixes in table.to_list(columns=columns):
-            db_name = self.get_ensembl_db_prefix(sp)
-            for prefix in prefixes.split(","):
-                self._stableid_species[prefix] = db_name
+    @classmethod
+    def from_table(cls, species_table: "Table") -> "SpeciesNameMap":
+        """uses TABLE_COLUMNS from species_table to create a SpeciesNameMap"""
+        abrv_genome = {}
+        abrv_common = {}
+        abrv_db = {}
+        for abrv, common, genome, db_prefix in species_table.to_list(
+            columns=TABLE_COLUMNS
+        ):
+            abrv = abrv.strip().lower()
+            abrv_genome[abrv] = genome.lower()
+            abrv_common[abrv] = common.lower()
+            abrv_db[abrv] = db_prefix.lower()
+
+        return cls(
+            abbrev_common=abrv_common, abbrev_genome=abrv_genome, abbrev_db=abrv_db
+        )
 
 
-Species = SpeciesNameMap()
-
-
-def species_from_ensembl_tree(tree: PhyloNode) -> dict[str, str]:
+def species_from_ensembl_tree(
+    tree: PhyloNode, species_map: SpeciesNameMap
+) -> dict[str, str]:
     """get species identifiers from an Ensembl tree"""
     tip_names = tree.get_tip_names()
     selected_species = {}
@@ -207,11 +220,12 @@ def species_from_ensembl_tree(tree: PhyloNode) -> dict[str, str]:
         # more general and look for matches
         for j in range(len(name_fields) + 1, 1, -1):
             n = "_".join(name_fields[:j])
-            if n in Species:
-                selected_species[Species.get_species_name(n)] = n
+            if n in species_map:
+                selected_species[species_map.get_species_name(n)] = n
                 break
         else:
-            raise ValueError(f"cannot establish species for {'_'.join(name_fields)}")
+            msg = f"cannot establish species for {'_'.join(name_fields)}"
+            raise ValueError(msg)
 
     return selected_species
 

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -205,6 +205,13 @@ class SpeciesNameMap:
             abbrev_common=abrv_common, abbrev_genome=abrv_genome, abbrev_db=abrv_db
         )
 
+    def get_subset(self, names: list[str]) -> "SpeciesNameMap":
+        """returns a species map subset for the given names"""
+        selected = {self.get_genome_name(n, level="raise") for n in names}
+        data = self.for_storage()
+        subset = {k: v for k, v in data.items() if k == "header" or k in selected}
+        return self.from_storage(subset)
+
 
 def species_from_ensembl_tree(
     tree: PhyloNode, species_map: SpeciesNameMap

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -94,19 +94,7 @@ class SpeciesNameMap:
         return repr(self.to_table())
 
     def __contains__(self, item: str) -> bool:
-        item = item.lower()
-        if " " in item:
-            return _genome_name_to_species_name(item) is not None
-
-        return any(
-            item in attr
-            for attr in (
-                self._abrv_to_db,
-                self._db_to_abrv,
-                self._common_to_abrv,
-                self._genome_to_abrv,
-            )
-        )
+        return bool(self._get_abbrev_for_name(item))
 
     def _repr_html_(self) -> str:
         table = self.to_table()
@@ -120,6 +108,8 @@ class SpeciesNameMap:
             print(f"WARN: {msg}")
 
     def _get_abbrev_for_name(self, name: str) -> StrOrNone:
+        if not isinstance(name, (str, bytes)):
+            return False
         name = name.lower()
         if name in self._abrv_to_db:
             return name
@@ -173,9 +163,15 @@ class SpeciesNameMap:
         self._handle_optional_errors(name, level)
         return None
 
-    def get_abbreviation(self, name: str) -> StrOrNone:
+    def get_abbreviation(
+        self, name: str, level: typing.Literal["ignore", "warn", "raise"] = "ignore"
+    ) -> StrOrNone:
         """returns the abbreviation for the given name"""
-        return self._get_abbrev_for_name(name)
+        if abrv := self._get_abbrev_for_name(name):
+            return abrv
+
+        self._handle_optional_errors(name, level)
+        return None
 
     def to_table(self) -> "Table":
         """returns cogent3 Table"""
@@ -192,6 +188,8 @@ class SpeciesNameMap:
     @classmethod
     def from_table(cls, species_table: "Table") -> "SpeciesNameMap":
         """uses TABLE_COLUMNS from species_table to create a SpeciesNameMap"""
+        from ensembl_tui._name import EnsemblDbName
+
         abrv_genome = {}
         abrv_common = {}
         abrv_db = {}
@@ -201,7 +199,7 @@ class SpeciesNameMap:
             abrv = abrv.strip().lower()
             abrv_genome[abrv] = genome.lower()
             abrv_common[abrv] = common.lower()
-            abrv_db[abrv] = db_prefix.lower()
+            abrv_db[abrv] = EnsemblDbName(db_prefix.lower()).prefix
 
         return cls(
             abbrev_common=abrv_common, abbrev_genome=abrv_genome, abbrev_db=abrv_db

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -214,3 +214,19 @@ def species_from_ensembl_tree(tree: PhyloNode) -> dict[str, str]:
             raise ValueError(f"cannot establish species for {'_'.join(name_fields)}")
 
     return selected_species
+
+
+def make_unique_abbrevs(names: list[str]) -> dict[str, str]:
+    """makes unique abbreviations from the species names"""
+    abbrevs: dict[str, str] = {}
+    for name in names:
+        parts = [p for p in name.split("_") if not _accession.search(p)]
+        parts = [parts[0][:3], *[p[:4] for p in parts[1:]], ""]
+        i = 1
+        while "-".join(p for p in parts if p) in abbrevs.values():
+            i += 1
+            parts[-1] = f"{i}"
+
+        abbrevs[name] = "-".join(p for p in parts if p)
+
+    return abbrevs

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -212,6 +212,26 @@ class SpeciesNameMap:
         subset = {k: v for k, v in data.items() if k == "header" or k in selected}
         return self.from_storage(subset)
 
+    def for_storage(self) -> dict[str, str]:
+        """creates a dict suitable for cfg storage"""
+        delim = "\t"
+        table = self.to_table()
+        primary = "genome_name"
+        header = [primary, *[c for c in table.header if c != primary]]
+        result = {"header": delim.join(header)}
+        for row in table.to_list(columns=header):
+            result[row[0]] = delim.join(row[1:])
+        return result
+
+    @classmethod
+    def from_storage(cls, d: dict[str, str]) -> "SpeciesNameMap":
+        """creates a SpeciesNameMap from a dict created by for_storage"""
+        delim = "\t"
+        header = d.pop("header").split(delim)
+        rows = [[key, *row.split(delim)] for key, row in d.items()]
+        table = make_table(header=header, data=rows, space=2)
+        return cls.from_table(table)
+
 
 def species_from_ensembl_tree(
     tree: PhyloNode, species_map: SpeciesNameMap

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -246,7 +246,7 @@ def species_from_ensembl_tree(
         for j in range(len(name_fields) + 1, 1, -1):
             n = "_".join(name_fields[:j])
             if n in species_map:
-                selected_species[species_map.get_species_name(n)] = n
+                selected_species[species_map.get_genome_name(n)] = n
                 break
         else:
             msg = f"cannot establish species for {'_'.join(name_fields)}"

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -17,7 +17,6 @@ import blosc2
 import hdf5plugin
 import numba
 import numpy
-import typing_extensions
 from cogent3.app.composable import define_app
 from cogent3.util.parallel import as_completed
 from rich import text as rich_text
@@ -122,28 +121,6 @@ def exec_command(
         sys.stderr.writelines(f"FAILED: {cmnd}\n{msg}")
         sys.exit(proc.returncode)
     return out.decode("utf8") if out is not None else None
-
-
-class CaseInsensitiveString(str):
-    """A case-insensitive string class. Comparisons are also case-insensitive."""
-
-    __slots__ = ("_hash", "_lower")
-
-    def __new__(cls, arg, h=None) -> "CaseInsensitiveString":
-        n = str.__new__(cls, str(arg))
-        n._lower = "".join(list(n)).lower()
-        n._hash = hash(n._lower)
-        return n
-
-    def __eq__(self, other: typing_extensions.Self) -> bool:
-        return self._lower == "".join(list(other)).lower()
-
-    def __hash__(self) -> int:
-        # dict hashing done via lower case
-        return self._hash
-
-    def __str__(self) -> str:
-        return "".join(list(self))
 
 
 def load_ensembl_checksum(path: pathlib.Path) -> dict:

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -48,9 +48,16 @@ def main() -> None:
 
 @main.command(**_click_command_opts)
 @cli_opt.dbrc_out
+@cli_opt.site
 @cli_opt.force
-def demo_config(outpath: pathlib.Path, force_overwrite: bool) -> None:
+def demo_config(outpath: pathlib.Path, site: str, force_overwrite: bool) -> None:
     """exports sample config and species table to the nominated path"""
+    from ensembl_tui._download import download_species_table
+
+    site_map = eti_site_map.get_site_map(site)
+    table = download_species_table(
+        site_map=site_map,
+    )
 
     outpath = outpath.expanduser()
     if outpath.exists() and not force_overwrite:
@@ -73,6 +80,8 @@ def demo_config(outpath: pathlib.Path, force_overwrite: bool) -> None:
             else:
                 # __pycache__ directory
                 shutil.rmtree(fn)
+    species_path = outpath / "species-full.tsv"
+    table.write(species_path)
     eti_util.print_colour(text=f"Contents written to {outpath}", colour="green")
 
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -88,8 +88,14 @@ def demo_config(outpath: pathlib.Path, site: str, force_overwrite: bool) -> None
 @main.command(**_click_command_opts)
 @cli_opt.cfgpath
 @cli_opt.debug
+@cli_opt.species_map
 @cli_opt.verbose
-def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
+def download(
+    configpath: pathlib.Path,
+    species_map: eti_species.SpeciesNameMap,
+    debug: bool,
+    verbose: bool,
+) -> None:
     """download data from Ensembl's ftp site"""
     from rich import progress
 
@@ -103,24 +109,17 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
         )
         sys.exit(1)
 
-    config = eti_config.read_config(config_path=configpath, root_dir=pathlib.Path.cwd())
+    config = eti_config.read_config(
+        config_path=configpath, root_dir=pathlib.Path.cwd(), species_map=species_map
+    )
     site_map = eti_site_map.get_site_map(config.host)
 
     if verbose:
         eti_util.print_colour(text=str(config), colour="yellow")
 
-    if not any((config.species_dbs, config.align_names)):
-        eti_util.print_colour(text="No genomes, no alignments specified", colour="red")
-        sys.exit(1)
-
     if not config.species_dbs:
-        species = eti_download.get_species_for_alignments(
-            site_map=site_map,
-            host=config.host,
-            release=config.release,
-            align_names=config.align_names,
-        )
-        config.update_species(species)
+        eti_util.print_colour(text="No genomes specified", colour="red")
+        sys.exit(1)
 
     if verbose:
         eti_util.print_colour(text=str(config.species_dbs), colour="yellow")

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -271,24 +271,19 @@ def species_summary(installed: pathlib.Path, species: str) -> None:
     """genome summary data for a species"""
 
     config = eti_config.read_installed_cfg(installed)
-    if species is None:
-        eti_util.print_colour(text="ERROR: a species name is required", colour="red")
-        sys.exit(1)
-
-    if len(species) > 1:
-        eti_util.print_colour(
-            text=f"ERROR: one species at a time, not {species!r}",
-            colour="red",
-        )
-        sys.exit(1)
-
-    species = species[0]
-    annot_db = eti_genome.load_annotations_for_species(
-        path=config.installed_genome(species=species),
+    selected_species = cli_opt.just_one_species(
+        data=species, species_map=config.species_map
     )
-    summary = eti_genome.get_species_gene_summary(annot_db=annot_db, species=species)
+    annot_db = eti_genome.load_annotations_for_species(
+        path=config.installed_genome(species=selected_species),
+    )
+    summary = eti_genome.get_species_gene_summary(
+        annot_db=annot_db, species=selected_species, species_map=config.species_map
+    )
     eti_util.rich_display(summary)
-    summary = eti_genome.get_species_repeat_summary(annot_db=annot_db, species=species)
+    summary = eti_genome.get_species_repeat_summary(
+        annot_db=annot_db, species=selected_species, species_map=config.species_map
+    )
     eti_util.rich_display(summary)
 
 
@@ -306,19 +301,11 @@ def dump_genes(
     """export meta-data table for genes from one species to <species>-<release>.gene_metadata.tsv"""
 
     config = eti_config.read_installed_cfg(installed)
-    if species is None:
-        eti_util.print_colour(text="ERROR: a species name is required", colour="red")
-        sys.exit(1)
-
-    if len(species) > 1:
-        eti_util.print_colour(
-            text=f"ERROR: one species at a time, not {species!r}",
-            colour="red",
-        )
-        sys.exit(1)
-
+    selected_species = cli_opt.just_one_species(
+        data=species, species_map=config.species_map
+    )
     annot_db = eti_genome.load_annotations_for_species(
-        path=config.installed_genome(species=species[0]),
+        path=config.installed_genome(species=selected_species),
     )
     path = annot_db.source
     table = eti_genome.get_gene_table_for_species(annot_db=annot_db, limit=limit)
@@ -417,7 +404,6 @@ def homologs(
     LOGGER.log_file_path = outdir / f"homologs-{ref}-{homology_type}.log"
 
     config = eti_config.read_installed_cfg(installed)
-    eti_species.Species.update_from_file(config.genomes_path / "species.tsv")
     # we all the protein coding gene IDs from the reference species
     genome = eti_genome.load_genome(config=config, species=ref)
 
@@ -564,7 +550,7 @@ def alignments(
 
     config = eti_config.read_installed_cfg(installed)
     align_db = eti_align.load_aligndb(config=config, align_name=align_name)
-    ref_species = eti_species.Species.get_ensembl_db_prefix(ref)
+    ref_species = config.species_map.get_ensembl_db_prefix(ref)
     if ref_species not in align_db.get_species_names():
         eti_util.print_colour(
             text=f"species {ref!r} not in the alignment",

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -103,7 +103,7 @@ def download(configpath: pathlib.Path, debug: bool, verbose: bool) -> None:
         )
         sys.exit(1)
 
-    config = eti_config.read_config(configpath, root_dir=pathlib.Path.cwd())
+    config = eti_config.read_config(config_path=configpath, root_dir=pathlib.Path.cwd())
     site_map = eti_site_map.get_site_map(config.host)
 
     if verbose:
@@ -182,7 +182,7 @@ def install(
     )
 
     configpath = download / eti_config.DOWNLOADED_CONFIG_NAME
-    config = eti_config.read_config(configpath)
+    config = eti_config.read_config(config_path=configpath, root_dir=None)
     if verbose:
         eti_util.print_colour(text=f"{config.install_path=}", colour="yellow")
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -239,13 +239,14 @@ def installed(installed: pathlib.Path) -> None:
     genome_dir = config.genomes_path
     if genome_dir.exists():
         species = [fn.name for fn in genome_dir.glob("*")]
-        data = {"species": [], "common name": []}
+        data = {"abbrev": [], "genome": [], "common name": []}
         for name in species:
-            cn = eti_species.Species.get_common_name(name, level="ignore")
+            cn = config.species_map.get_common_name(name, level="ignore")
             if not cn:
                 continue
-            data["species"].append(name)
+            data["genome"].append(name)
             data["common name"].append(cn)
+            data["abbrev"].append(config.species_map.get_abbreviation(name))
 
         table = make_table(data=data, title="Installed genomes:")
         eti_util.rich_display(table)

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -267,7 +267,7 @@ def installed(installed: pathlib.Path) -> None:
 @main.command(**_click_command_opts)
 @cli_opt.installed
 @cli_opt.species
-def species_summary(installed: pathlib.Path, species: str) -> None:
+def species_summary(installed: pathlib.Path, species: list[str]) -> None:
     """genome summary data for a species"""
 
     config = eti_config.read_installed_cfg(installed)

--- a/src/ensembl_tui/data/species.tsv
+++ b/src/ensembl_tui/data/species.tsv
@@ -1,318 +1,349 @@
-Species name	Common name	Ensembl stableid Prefix
-Acanthochromis polyacanthus	Spiny chromis	ENSAPO
-Accipiter nisus	Eurasian sparrowhawk	ENSANI
-Ailuropoda melanoleuca	Giant panda	ENSAME
-Amazona collaria	Yellow-billed parrot	ENSACO
-Amphilophus citrinellus	Midas cichlid	ENSACI
-Amphiprion ocellaris	Clown anemonefish	ENSAOC
-Amphiprion percula	Orange clownfish	ENSAPE
-Anabas testudineus	Climbing perch	ENSATE
-Anas platyrhynchos	Mallard	ENSAPL
-Anas platyrhynchos platyrhynchos	Duck	ENSAPL
-Anas zonorhyncha	Eastern spot-billed duck	ENSAZO
-Anolis carolinensis	Green anole	ENSACA
-Anser brachyrhynchus	Pink-footed goose	ENSABR
-Anser cygnoides	Swan goose	ENSACD
-Aotus nancymaae	Ma's night monkey	ENSANA
-Apteryx haastii	Great spotted kiwi	ENSAHA
-Apteryx owenii	Little spotted kiwi	ENSAOW
-Apteryx rowi	Okarito brown kiwi	ENSARW
-Aquila chrysaetos chrysaetos	Golden eagle	ENSACC
-Astatotilapia calliptera	Eastern happy	ENSACL
-Astyanax mexicanus	Mexican tetra	ENSAMX
-Astyanax mexicanus pachon	Pachon cavefish	
-Athene cunicularia	Burrowing owl	ENSACU
-Balaenoptera musculus	Blue whale	ENSBMS
-Betta splendens	Siamese fighting fish	ENSBSL
-Bison bison bison	American bison	ENSBBB
-Bos grunniens	Domestic yak	ENSBGR
-Bos indicus hybrid	Hybrid - Bos Indicus	
-Bos mutus	Wild yak	ENSBMU
-Bos taurus	Cow	ENSBTA
-Bos taurus hybrid	Hybrid - Bos Taurus	
-Bubo bubo	Eurasian eagle-owl	ENSBOB
-Buteo japonicus	Eastern buzzard	ENSBJA
-Caenorhabditis elegans	Caenorhabditis elegans (PRJNA13758)	
-Cairina moschata domestica	Muscovy Duck (domestic type)	ENSCMM
-Calidris pugnax	Ruff	ENSCPU
-Calidris pygmaea	Spoon-billed sandpiper	ENSCPG
-Callithrix jacchus	White-tufted-ear marmoset	ENSCJA
-Callorhinchus milii	Elephant shark	ENSCMI
-Camarhynchus parvulus	Small tree finch	ENSCPV
-Camelus dromedarius	Arabian camel	ENSCDR
-Canis lupus dingo	Dingo	ENSCAF
-Canis lupus familiaris	Dog	ENSCAF
-Canis lupus familiarisbasenji	Dog - Basenji	
-Canis lupus familiarisboxer	Dog - Boxer	
-Canis lupus familiarisgreatdane	Dog - Great Dane	
-Canis lupus familiarisgsd	Dog - German Shepherd	
-Capra hircus	Goat	ENSCHI
-Capra hircus blackbengal	Goat (black bengal)	
-Carassius auratus	Goldfish	ENSCAR
-Carlito syrichta	Tarsier	ENSTSY
-Castor canadensis	American beaver	ENSCCN
-Catagonus wagneri	Chacoan peccary	ENSCWA
-Catharus ustulatus	Swainson's thrush	ENSCUS
-Cavia aperea	Brazilian guinea pig	ENSCAP
-Cavia porcellus	Guinea Pig	ENSCPO
-Cebus imitator	Panamanian white-faced capuchin	ENSCCA
-Cercocebus atys	Sooty mangabey	ENSCAT
-Cervus hanglu yarkandensis	Yarkand deer	ENSCHY
-Chelonoidis abingdonii	Abingdon island giant tortoise	ENSCAB
-Chelydra serpentina	Common snapping turtle	ENSCSR
-Chinchilla lanigera	Long-tailed chinchilla	ENSCLA
-Chlorocebus sabaeus	Vervet-AGM	ENSCSA
-Choloepus hoffmanni	Sloth	ENSCHO
-Chrysemys picta bellii	Painted turtle	ENSCPB
-Chrysolophus pictus	Golden pheasant	ENSCPI
-Ciona intestinalis	C.intestinalis	ENSCIN
-Ciona savignyi	C.savignyi	ENSCSAV
-Clupea harengus	Atlantic herring	ENSCHA
-Colobus angolensis palliatus	Angola colobus	ENSCAN
-Corvus moneduloides	New Caledonian crow	ENSCMU
-Cottoperca gobio	Channel bull blenny	ENSCGO
-Coturnix japonica	Japanese quail	ENSCJP
-Cricetulus griseus chok1gshd	Chinese hamster CHOK1GS	
-Cricetulus griseus crigri	Chinese hamster CriGri	
-Cricetulus griseus picr	Chinese hamster PICR	
-Crocodylus porosus	Australian saltwater crocodile	ENSCPR
-Cyanistes caeruleus	Blue tit	ENSCCE
-Cyclopterus lumpus	Lumpfish	ENSCLM
-Cynoglossus semilaevis	Tongue sole	ENSCSE
-Cyprinodon variegatus	Sheepshead minnow	ENSCVA
-Cyprinus carpio carpio	Common carp	ENSCCR
-Cyprinus carpio germanmirror	Common carp german mirror	
-Cyprinus carpio hebaored	Common carp hebao red	
-Cyprinus carpio huanghe	Common carp huanghe	
-Danio rerio	Zebrafish	ENSDAR
-Dasypus novemcinctus	Armadillo	ENSDNO
-Delphinapterus leucas	Beluga whale	ENSDLE
-Denticeps clupeoides	Denticle herring	ENSDCD
-Dicentrarchus labrax	European seabass	ENSDLA
-Dipodomys ordii	Kangaroo rat	ENSDOR
-Dromaius novaehollandiae	Emu	ENSDNV
-Drosophila melanogaster	Drosophila melanogaster (Fruit fly)	
-Echeneis naucrates	Live sharksucker	ENSENL
-Echinops telfairi	Lesser hedgehog tenrec	ENSETE
-Electrophorus electricus	Electric eel	ENSEEE
-Eptatretus burgeri	Hagfish	ENSEBU
-Equus asinus	Donkey	ENSEAS
-Equus caballus	Horse	ENSECA
-Erinaceus europaeus	Hedgehog	ENSEEU
-Erpetoichthys calabaricus	Reedfish	ENSECR
-Erythrura gouldiae	Gouldian finch	ENSEGO
-Esox lucius	Northern pike	ENSELU
-Falco tinnunculus	Common kestrel	ENSFTI
-Felis catus	Cat	ENSFCA
-Ficedula albicollis	Collared flycatcher	ENSFAL
-Fukomys damarensis	Damara mole rat	ENSFDA
-Fundulus heteroclitus	Mummichog	ENSFHE
-Gadus morhua	Atlantic cod	ENSGMO
-Gallus gallus	Chicken	ENSGAL
-Gallus gallus gca000002315v5	Chicken (Red Jungle fowl)	
-Gallus gallus gca016700215v2	Chicken (paternal White leghorn layer)	
-Gambusia affinis	Western mosquitofish	ENSGAF
-Gasterosteus aculeatus	Stickleback	ENSGAC
-Geospiza fortis	Medium ground-finch	ENSGFO
-Gopherus agassizii	Agassiz's desert tortoise	ENSGAG
-Gopherus evgoodei	Goodes thornscrub tortoise	ENSGEV
-Gorilla gorilla	Gorilla	ENSGGO
-Gouania willdenowi	Blunt-snouted clingfish	ENSGWI
-Haplochromis burtoni	Burton's mouthbrooder	ENSHBU
-Heterocephalus glaber female	Naked mole-rat female	
-Heterocephalus glaber male	Naked mole-rat male	
-Hippocampus comes	Tiger tail seahorse	ENSHCO
-Homo sapiens	Human	ENS
-Hucho hucho	Huchen	ENSHHU
-Ictalurus punctatus	Channel catfish	ENSIPU
-Ictidomys tridecemlineatus	Squirrel	ENSSTO
-Jaculus jaculus	Lesser Egyptian jerboa	ENSJJA
-Junco hyemalis	Dark-eyed junco	ENSJHY
-Kryptolebias marmoratus	Mangrove rivulus	ENSKMA
-Labrus bergylta	Ballan wrasse	ENSLBE
-Larimichthys crocea	Large yellow croaker	ENSLCR
-Lates calcarifer	Barramundi perch	ENSLCA
-Laticauda laticaudata	Blue-ringed sea krait	ENSLLT
-Latimeria chalumnae	Coelacanth	ENSLAC
-Lepidothrix coronata	Blue-crowned manakin	ENSLCO
-Lepisosteus oculatus	Spotted gar	ENSLOC
-Leptobrachium leishanense	Leishan spiny toad	ENSLLE
-Lonchura striata domestica	Bengalese finch	ENSLSD
-Loxodonta africana	Elephant	ENSLAF
-Lynx canadensis	Canada lynx	ENSLCN
-Macaca fascicularis	Crab-eating macaque	ENSMFA
-Macaca mulatta	Macaque	ENSMMU
-Macaca nemestrina	Pig-tailed macaque	ENSMNE
-Malurus cyaneus samueli	Superb fairywren	ENSMCS
-Manacus vitellinus	Golden-collared manakin	ENSMVI
-Mandrillus leucophaeus	Drill	ENSMLE
-Marmota marmota marmota	Alpine marmot	ENSMMM
-Mastacembelus armatus	Zig-zag eel	ENSMAM
-Maylandia zebra	Zebra mbuna	ENSMZE
-Meleagris gallopavo	Turkey	ENSMGA
-Melopsittacus undulatus	Budgerigar	ENSMUN
-Meriones unguiculatus	Mongolian gerbil	ENSMUG
-Mesocricetus auratus	Golden Hamster	ENSMAU
-Microcebus murinus	Mouse Lemur	ENSMIC
-Microtus ochrogaster	Prairie vole	ENSMOC
-Mola mola	Ocean sunfish	ENSMMO
-Monodelphis domestica	Opossum	ENSMOD
-Monodon monoceros	Narwhal	ENSMMN
-Monopterus albus	Swamp eel	ENSMAL
-Moschus moschiferus	Siberian musk deer	ENSMMS
-Mus caroli	Ryukyu mouse	MGP_CAROLIEiJ_
-Mus musculus	Mouse	MGP_C57BL6NJ_
-Mus musculus 129s1svimj	Mouse 129S1/SvImJ	
-Mus musculus aj	Mouse A/J	
-Mus musculus akrj	Mouse AKR/J	
-Mus musculus balbcj	Mouse BALB/cJ	
-Mus musculus c3hhej	Mouse C3H/HeJ	
-Mus musculus c57bl6nj	Mouse C57BL/6NJ	
-Mus musculus casteij	Mouse CAST/EiJ	
-Mus musculus cbaj	Mouse CBA/J	
-Mus musculus dba2j	Mouse DBA/2J	
-Mus musculus fvbnj	Mouse FVB/NJ	
-Mus musculus lpj	Mouse LP/J	
-Mus musculus nodshiltj	Mouse NOD/ShiLtJ	
-Mus musculus nzohlltj	Mouse NZO/HlLtJ	
-Mus musculus pwkphj	Mouse PWK/PhJ	
-Mus musculus wsbeij	Mouse WSB/EiJ	
-Mus pahari	Shrew mouse	MGP_PahariEiJ_
-Mus spicilegus	Steppe mouse	ENSMSI
-Mus spretus	Algerian mouse	MGP_SPRETEiJ_
-Mustela putorius furo	Ferret	ENSMPU
-Myotis lucifugus	Microbat	ENSMLU
-Myripristis murdjan	Pinecone soldierfish	ENSMMD
-Naja naja	Indian cobra	ENSNNA
-Nannospalax galili	Upper Galilee mountains blind mole rat	ENSNGA
-Neogobius melanostomus	Round goby	ENSNML
-Neolamprologus brichardi	Lyretail cichlid	ENSNBR
-Neovison vison	American mink	ENSNVI
-Nomascus leucogenys	Gibbon	ENSNLE
-Notamacropus eugenii	Wallaby	ENSMEU
-Notechis scutatus	Mainland tiger snake	ENSNSU
-Nothobranchius furzeri	Turquoise killifish	ENSNFU
-Nothoprocta perdicaria	Chilean tinamou	ENSNPE
-Numida meleagris	Helmeted guineafowl	ENSNME
-Ochotona princeps	Pika	ENSOPR
-Octodon degus	Degu	ENSODE
-Oncorhynchus kisutch	Coho salmon	ENSOKI
-Oncorhynchus mykiss	Rainbow trout	ENSOMY
-Oncorhynchus tshawytscha	Chinook salmon	ENSOTS
-Oreochromis aureus	Blue tilapia	ENSOAB
-Oreochromis niloticus	Nile tilapia	ENSONI
-Ornithorhynchus anatinus	Platypus	ENSOAN
-Oryctolagus cuniculus	Rabbit	ENSOCU
-Oryzias javanicus	Javanese ricefish	ENSOJA
-Oryzias latipes	Japanese medaka HdrR	ENSORL
-Oryzias latipes hni	Japanese medaka HNI	
-Oryzias latipes hsok	Japanese medaka HSOK	
-Oryzias melastigma	Indian medaka	ENSOME
-Oryzias sinensis	Chinese medaka	ENSOSI
-Otolemur garnettii	Bushbaby	ENSOGA
-Otus sunia	Oriental scops-owl	ENSOSU
-Ovis aries	Sheep (texel)	ENSOAR
-Ovis aries rambouillet	Sheep	
-Pan paniscus	Bonobo	ENSPPA
-Pan troglodytes	Chimpanzee	ENSPTR
-Panthera leo	Lion	ENSPLO
-Panthera pardus	Leopard	ENSPPR
-Panthera tigris altaica	Tiger	ENSPTI
-Papio anubis	Olive baboon	ENSPAN
-Parambassis ranga	Indian glassy fish	ENSPRN
-Paramormyrops kingsleyae	Paramormyrops kingsleyae	ENSPKI
-Parus major	Great Tit	ENSPMJ
-Pavo cristatus	Indian peafowl	ENSPST
-Pelodiscus sinensis	Chinese softshell turtle	ENSPSI
-Pelusios castaneus	West African mud turtle	ENSPCE
-Periophthalmus magnuspinnatus	Periophthalmus magnuspinnatus	ENSPMG
-Peromyscus maniculatus bairdii	Northern American deer mouse	ENSPEM
-Petromyzon marinus	Lamprey	ENSPMA
-Phascolarctos cinereus	Koala	ENSPCI
-Phasianus colchicus	Ring-necked pheasant	ENSPCL
-Phocoena sinus	Vaquita	ENSPSN
-Physeter catodon	Sperm whale	ENSPCT
-Piliocolobus tephrosceles	Ugandan red Colobus	ENSPTE
-Podarcis muralis	Common wall lizard	ENSPMR
-Poecilia formosa	Amazon molly	ENSPFO
-Poecilia latipinna	Sailfin molly	ENSPLA
-Poecilia mexicana	Shortfin molly	ENSPME
-Poecilia reticulata	Guppy	ENSPRE
-Pogona vitticeps	Central bearded dragon	ENSPVI
-Pongo abelii	Sumatran orangutan	ENSPPY
-Procavia capensis	Hyrax	ENSPCA
-Prolemur simus	Greater bamboo lemur	ENSPSM
-Propithecus coquereli	Coquerel's sifaka	ENSPCO
-Pseudonaja textilis	Eastern brown snake	ENSPTX
-Pteropus vampyrus	Megabat	ENSPVA
-Pundamilia nyererei	Makobe Island cichlid	ENSPNY
-Pygocentrus nattereri	Red-bellied piranha	ENSPNA
-Rattus norvegicus	Rat	ENSRNO
-Rattus norvegicus shrspbbbutx	Rat - SHRSP/BbbUtx	
-Rattus norvegicus shrutx	Rat - SHR/Utx RGD_8142385	
-Rattus norvegicus wkybbb	Rat - WKY/Bbb RGD_1581635	
-Rhinolophus ferrumequinum	Greater horseshoe bat	ENSRFE
-Rhinopithecus bieti	Black snub-nosed monkey	ENSRBI
-Rhinopithecus roxellana	Golden snub-nosed monkey	ENSRRO
-Saccharomyces cerevisiae	Saccharomyces cerevisiae	
-Saimiri boliviensis boliviensis	Bolivian squirrel monkey	ENSSBO
-Salarias fasciatus	Jewelled blenny	ENSSFA
-Salmo salar	Atlantic salmon	ENSSSA
-Salmo trutta	Brown trout	ENSSTU
-Salvator merianae	Argentine black and white tegu	ENSSMR
-Sander lucioperca	Pike-perch	ENSSLU
-Sarcophilus harrisii	Tasmanian devil	ENSSHA
-Sciurus vulgaris	Eurasian red squirrel	ENSSVL
-Scleropages formosus	Asian bonytongue	ENSCHA
-Scophthalmus maximus	Turbot	ENSSMA
-Serinus canaria	Common canary	ENSSCA
-Seriola dumerili	Greater amberjack	ENSSDU
-Seriola lalandi dorsalis	Yellowtail amberjack	ENSSLD
-Sinocyclocheilus anshuiensis	Blind barbel	ENSSAN
-Sinocyclocheilus grahami	Golden-line barbel	ENSSGR
-Sinocyclocheilus rhinocerous	Horned golden-line barbel	ENSSRH
-Sorex araneus	Shrew	ENSSAR
-Sparus aurata	Gilthead seabream	ENSSAU
-Spermophilus dauricus	Daurian ground squirrel	ENSSDA
-Sphaeramia orbicularis	Orbiculate cardinalfish	ENSSOR
-Sphenodon punctatus	Tuatara	ENSSPU
-Stachyris ruficeps	Rufous-capped babbler	
-Stegastes partitus	Bicolor damselfish	ENSSPA
-Strigops habroptila	Kakapo	ENSSHB
-Strix occidentalis caurina	Northern spotted owl	ENSSOC
-Struthio camelus australis	African ostrich	ENSSCU
-Suricata suricatta	Meerkat	ENSSSU
-Sus scrofa	Pig	ENSSSC
-Sus scrofa bamei	Pig - Bamei	
-Sus scrofa berkshire	Pig - Berkshire	
-Sus scrofa hampshire	Pig - Hampshire	
-Sus scrofa jinhua	Pig - Jinhua	
-Sus scrofa landrace	Pig - Landrace	
-Sus scrofa largewhite	Pig - Largewhite	
-Sus scrofa meishan	Pig - Meishan	
-Sus scrofa pietrain	Pig - Pietrain	
-Sus scrofa rongchang	Pig - Rongchang	
-Sus scrofa tibetan	Pig - Tibetan	
-Sus scrofa usmarc	Pig USMARC	
-Sus scrofa wuzhishan	Pig - Wuzhishan	
-Taeniopygia guttata	Zebra finch	ENSTGU
-Takifugu rubripes	Fugu	ENSTRU
-Terrapene carolina triunguis	Three-toed box turtle	ENSTMT
-Tetraodon nigroviridis	Tetraodon	ENSTNI
-Theropithecus gelada	Gelada	ENSTGE
-Tupaia belangeri	Tree Shrew	ENSTBE
-Tursiops truncatus	Dolphin	ENSTTR
-Urocitellus parryii	Arctic ground squirrel	ENSUPA
-Ursus americanus	American black bear	ENSUAM
-Ursus maritimus	Polar bear	ENSUMA
-Ursus thibetanus thibetanus	Asiatic black bear	ENSUTT
-Varanus komodoensis	Komodo dragon	ENSVKK
-Vicugna pacos	Alpaca	ENSVPA
-Vombatus ursinus	Common wombat	ENSVUR
-Vulpes vulpes	Red fox	ENSVVU
-Xenopus tropicalis	Tropical clawed frog	ENSXET
-Xiphophorus couchianus	Monterrey platyfish	ENSXCO
-Xiphophorus maculatus	Platyfish	ENSXMA
-Zalophus californianus	California sea lion	ENSZCA
-Zonotrichia albicollis	White-throated sparrow	ENSZAL
-Zosterops lateralis melanops	Silver-eye	ENSZLM
+abbrev	common_name	genome_name	db_prefix	taxonomy_id
+aca-poly	Spiny chromis	acanthochromis_polyacanthus	acanthochromis_polyacanthus	80966
+acc-nisu	Eurasian sparrowhawk	accipiter_nisus	accipiter_nisus	211598
+ail-mela	Giant panda	ailuropoda_melanoleuca	ailuropoda_melanoleuca	9646
+ama-coll	Yellow-billed parrot	amazona_collaria	amazona_collaria	241587
+amp-citr	Midas cichlid	amphilophus_citrinellus	amphilophus_citrinellus	61819
+amp-ocel	Clown anemonefish	amphiprion_ocellaris	amphiprion_ocellaris	80972
+amp-perc	Orange clownfish	amphiprion_percula	amphiprion_percula	161767
+ana-test	Climbing perch	anabas_testudineus	anabas_testudineus	64144
+ana-plat	Mallard	anas_platyrhynchos	anas_platyrhynchos	8839
+ana-plat-plat	Duck	anas_platyrhynchos_platyrhynchos	anas_platyrhynchos_platyrhynchos	8840
+ana-zono	Eastern spot-billed duck	anas_zonorhyncha	anas_zonorhyncha	75864
+ano-caro	Green anole	anolis_carolinensis	anolis_carolinensis	28377
+ans-brac	Pink-footed goose	anser_brachyrhynchus	anser_brachyrhynchus	132585
+ans-cygn	Swan goose	anser_cygnoides	anser_cygnoides	8845
+aot-nanc	Ma's night monkey	aotus_nancymaae	aotus_nancymaae	37293
+apt-haas	Great spotted kiwi	apteryx_haastii	apteryx_haastii	8823
+apt-owen	Little spotted kiwi	apteryx_owenii	apteryx_owenii	8824
+apt-rowi	Okarito brown kiwi	apteryx_rowi	apteryx_rowi	308060
+aqu-chry-chry	Golden eagle	aquila_chrysaetos_chrysaetos	aquila_chrysaetos_chrysaetos	223781
+ast-call	Eastern happy	astatotilapia_calliptera	astatotilapia_calliptera	8154
+ast-mexi	Mexican tetra	astyanax_mexicanus	astyanax_mexicanus	7994
+ast-mexi-pach	Pachon cavefish	astyanax_mexicanus_pachon	astyanax_mexicanus_pachon	7994
+ath-cuni	Burrowing owl	athene_cunicularia	athene_cunicularia	194338
+bal-musc	Blue whale	balaenoptera_musculus	balaenoptera_musculus	9771
+bet-sple	Siamese fighting fish	betta_splendens	betta_splendens	158456
+bis-biso-biso	American bison	bison_bison_bison	bison_bison_bison	43346
+bos-grun	Domestic yak	bos_grunniens	bos_grunniens	30521
+bos-indi-hybr	Hybrid - Bos Indicus	bos_indicus_hybrid	bos_indicus_hybrid	30522
+bos-mutu	Wild yak	bos_mutus	bos_mutus	72004
+bos-taur	Cattle	bos_taurus	bos_taurus	9913
+bos-taur-hybr	Hybrid - Bos Taurus	bos_taurus_hybrid	bos_taurus_hybrid	30522
+bos-taur-tuli	Cattle - Tuli	bos_taurus_tuli	bos_taurus_tuli	9913
+bos-taur-wagy	Cattle - Wagyu	bos_taurus_wagyu	bos_taurus_wagyu	9913
+bub-bubo	Eurasian eagle-owl	bubo_bubo	bubo_bubo	30461
+but-japo	Eastern buzzard	buteo_japonicus	buteo_japonicus	224669
+cae-eleg	Caenorhabditis elegans (Nematode, N2)	caenorhabditis_elegans	caenorhabditis_elegans	6239
+cai-mosc-dome	Muscovy Duck (domestic type)	cairina_moschata_domestica	cairina_moschata_domestica	8855
+cal-pugn	Ruff	calidris_pugnax	calidris_pugnax	198806
+cal-pygm	Spoon-billed sandpiper	calidris_pygmaea	calidris_pygmaea	425635
+cal-jacc	White-tufted-ear marmoset	callithrix_jacchus	callithrix_jacchus	9483
+cal-mili	Elephant shark	callorhinchus_milii	callorhinchus_milii	7868
+cam-parv	Small tree finch	camarhynchus_parvulus	camarhynchus_parvulus	87175
+cam-drom	Arabian camel	camelus_dromedarius	camelus_dromedarius	9838
+can-lupu-ding	Dingo	canis_lupus_dingo	canis_lupus_dingo	286419
+can-lupu-fami	Dog	canis_lupus_familiaris	canis_lupus_familiaris	9615
+can-lupu-fami-2	Dog - Basenji	canis_lupus_familiarisbasenji	canis_lupus_familiarisbasenji	9615
+can-lupu-fami-3	Dog - Boxer	canis_lupus_familiarisboxer	canis_lupus_familiarisboxer	9615
+can-lupu-fami-4	Dog - Great Dane	canis_lupus_familiarisgreatdane	canis_lupus_familiarisgreatdane	9615
+can-lupu-fami-5	Dog - German Shepherd	canis_lupus_familiarisgsd	canis_lupus_familiarisgsd	9615
+cap-hirc	Goat	capra_hircus	capra_hircus	9925
+cap-hirc-blac	Goat (black bengal)	capra_hircus_blackbengal	capra_hircus_blackbengal	9925
+cap-hirc-2	Goat - Saanen Dairy	capra_hircus_gca015443085v1	capra_hircus_gca015443085v1	9925
+cap-hirc-3	Goat - Xinong Saanen Dairy	capra_hircus_gca026652205v1	capra_hircus_gca026652205v1	9925
+car-aura	Goldfish	carassius_auratus	carassius_auratus	7957
+car-syri	Tarsier	carlito_syrichta	carlito_syrichta	1868482
+cas-cana	American beaver	castor_canadensis	castor_canadensis	51338
+cat-wagn	Chacoan peccary	catagonus_wagneri	catagonus_wagneri	51154
+cat-ustu	Swainson's thrush	catharus_ustulatus	catharus_ustulatus	91951
+cav-aper	Brazilian guinea pig	cavia_aperea	cavia_aperea	37548
+cav-porc	Guinea Pig	cavia_porcellus	cavia_porcellus	10141
+ceb-imit	Panamanian white-faced capuchin	cebus_imitator	cebus_imitator	2715852
+cer-atys	Sooty mangabey	cercocebus_atys	cercocebus_atys	9531
+cer-hang-yark	Yarkand deer	cervus_hanglu_yarkandensis	cervus_hanglu_yarkandensis	84702
+che-abin	Abingdon island giant tortoise	chelonoidis_abingdonii	chelonoidis_abingdonii	106734
+che-serp	Common snapping turtle	chelydra_serpentina	chelydra_serpentina	8475
+chi-lani	Long-tailed chinchilla	chinchilla_lanigera	chinchilla_lanigera	34839
+chl-saba	Vervet-AGM	chlorocebus_sabaeus	chlorocebus_sabaeus	60711
+cho-hoff	Sloth	choloepus_hoffmanni	choloepus_hoffmanni	9358
+chr-pict-bell	Painted turtle	chrysemys_picta_bellii	chrysemys_picta_bellii	8478
+chr-pict	Golden pheasant	chrysolophus_pictus	chrysolophus_pictus	9089
+cio-inte	C.intestinalis	ciona_intestinalis	ciona_intestinalis	7719
+cio-savi	C.savignyi	ciona_savignyi	ciona_savignyi	51511
+clu-hare	Atlantic herring 	clupea_harengus	clupea_harengus	7950
+col-ango-pall	Angola colobus	colobus_angolensis_palliatus	colobus_angolensis_palliatus	336983
+cor-mone	New Caledonian crow	corvus_moneduloides	corvus_moneduloides	1196302
+cot-gobi	Channel bull blenny	cottoperca_gobio	cottoperca_gobio	56716
+cot-japo	Japanese quail	coturnix_japonica	coturnix_japonica	93934
+cri-gris	Chinese hamster CHOK1GS	cricetulus_griseus_chok1gshd	cricetulus_griseus_chok1gshd	10029
+cri-gris-crig	Chinese hamster CriGri	cricetulus_griseus_crigri	cricetulus_griseus_crigri	10029
+cri-gris-picr	Chinese hamster PICR	cricetulus_griseus_picr	cricetulus_griseus_picr	10029
+cro-poro	Australian saltwater crocodile	crocodylus_porosus	crocodylus_porosus	8502
+cya-caer	Blue tit	cyanistes_caeruleus	cyanistes_caeruleus	156563
+cyc-lump	Lumpfish	cyclopterus_lumpus	cyclopterus_lumpus	8103
+cyn-semi	Tongue sole	cynoglossus_semilaevis	cynoglossus_semilaevis	244447
+cyp-vari	Sheepshead minnow	cyprinodon_variegatus	cyprinodon_variegatus	28743
+cyp-carp-carp	Common carp	cyprinus_carpio_carpio	cyprinus_carpio_carpio	630221
+cyp-carp-germ	Common carp german mirror	cyprinus_carpio_germanmirror	cyprinus_carpio_germanmirror	7962
+cyp-carp-heba	Common carp hebao red	cyprinus_carpio_hebaored	cyprinus_carpio_hebaored	7962
+cyp-carp-huan	Common carp huanghe	cyprinus_carpio_huanghe	cyprinus_carpio_huanghe	7962
+dan-reri	Zebrafish	danio_rerio	danio_rerio	7955
+das-nove	Armadillo	dasypus_novemcinctus	dasypus_novemcinctus	9361
+del-leuc	Beluga whale	delphinapterus_leucas	delphinapterus_leucas	9749
+den-clup	Denticle herring	denticeps_clupeoides	denticeps_clupeoides	299321
+dic-labr	European seabass	dicentrarchus_labrax	dicentrarchus_labrax	13489
+dip-ordi	Kangaroo rat	dipodomys_ordii	dipodomys_ordii	10020
+dro-nova	Emu	dromaius_novaehollandiae	dromaius_novaehollandiae	8790
+dro-mela	Drosophila melanogaster - (Fruit fly)	drosophila_melanogaster	drosophila_melanogaster	7227
+ech-nauc	Live sharksucker	echeneis_naucrates	echeneis_naucrates	173247
+ech-telf	Lesser hedgehog tenrec	echinops_telfairi	echinops_telfairi	9371
+ele-elec	Electric eel	electrophorus_electricus	electrophorus_electricus	8005
+ept-burg	Hagfish	eptatretus_burgeri	eptatretus_burgeri	7764
+equ-asin	Donkey	equus_asinus	equus_asinus	9793
+equ-caba	Horse	equus_caballus	equus_caballus	9796
+eri-euro	Hedgehog	erinaceus_europaeus	erinaceus_europaeus	9365
+erp-cala	Reedfish	erpetoichthys_calabaricus	erpetoichthys_calabaricus	27687
+ery-goul	Gouldian finch	erythrura_gouldiae	erythrura_gouldiae	44316
+eso-luci	Northern pike	esox_lucius	esox_lucius	8010
+fal-tinn	Common kestrel	falco_tinnunculus	falco_tinnunculus	100819
+fel-catu	Domestic cat	felis_catus	felis_catus	9685
+fel-catu-abys	Cat - Abyssinian	felis_catus_abyssinian	felis_catus_abyssinian	9685
+fic-albi	Collared flycatcher	ficedula_albicollis	ficedula_albicollis	59894
+fuk-dama	Damara mole rat	fukomys_damarensis	fukomys_damarensis	885580
+fun-hete	Mummichog	fundulus_heteroclitus	fundulus_heteroclitus	8078
+gad-morh	Atlantic cod	gadus_morhua	gadus_morhua	8049
+gad-morh-2	Atlantic cod - Celtic sea	gadus_morhua_gca010882105v1	gadus_morhua_gca010882105v1	8049
+gal-gall	Chicken	gallus_gallus	gallus_gallus	9031
+gal-gall-2	Chicken (Red Jungle fowl)	gallus_gallus_gca000002315v5	gallus_gallus_gca000002315v5	9031
+gal-gall-3	Chicken (paternal White leghorn layer)	gallus_gallus_gca016700215v2	gallus_gallus_gca016700215v2	9031
+gam-affi	Western mosquitofish	gambusia_affinis	gambusia_affinis	33528
+gas-acul	Stickleback	gasterosteus_aculeatus	gasterosteus_aculeatus	481459
+gas-acul-2	Three-spined sticklebacki - Freshwater BOT	gasterosteus_aculeatus_gca006229185v1	gasterosteus_aculeatus_gca006229185v1	69293
+gas-acul-3	Three-spined sticklebacki - Marine BAM	gasterosteus_aculeatus_gca006232265v1	gasterosteus_aculeatus_gca006232265v1	69293
+gas-acul-4	Three-spined sticklebacki - Marine SYL	gasterosteus_aculeatus_gca006232285v1	gasterosteus_aculeatus_gca006232285v1	69293
+geo-fort	Medium ground-finch	geospiza_fortis	geospiza_fortis	48883
+gop-agas	Agassiz's desert tortoise	gopherus_agassizii	gopherus_agassizii	38772
+gop-evgo	Goodes thornscrub tortoise	gopherus_evgoodei	gopherus_evgoodei	1825980
+gor-gori	Gorilla	gorilla_gorilla	gorilla_gorilla	9595
+gou-will	Blunt-snouted clingfish	gouania_willdenowi	gouania_willdenowi	441366
+hap-burt	Burton's mouthbrooder	haplochromis_burtoni	haplochromis_burtoni	8153
+het-glab-fema	Naked mole-rat female	heterocephalus_glaber_female	heterocephalus_glaber_female	10181
+het-glab-male	Naked mole-rat male	heterocephalus_glaber_male	heterocephalus_glaber_male	10181
+hip-come	Tiger tail seahorse	hippocampus_comes	hippocampus_comes	109280
+hom-sapi	Human	homo_sapiens	homo_sapiens	9606
+huc-huch	Huchen	hucho_hucho	hucho_hucho	62062
+ict-punc	Channel catfish	ictalurus_punctatus	ictalurus_punctatus	7998
+ict-trid	Squirrel	ictidomys_tridecemlineatus	ictidomys_tridecemlineatus	43179
+jac-jacu	Lesser Egyptian jerboa	jaculus_jaculus	jaculus_jaculus	51337
+jun-hyem	Dark-eyed junco	junco_hyemalis	junco_hyemalis	40217
+kry-marm	Mangrove rivulus	kryptolebias_marmoratus	kryptolebias_marmoratus	37003
+lab-berg	Ballan wrasse	labrus_bergylta	labrus_bergylta	56723
+lar-croc	Large yellow croaker	larimichthys_crocea	larimichthys_crocea	215358
+lat-calc	Barramundi perch	lates_calcarifer	lates_calcarifer	8187
+lat-lati	Blue-ringed sea krait	laticauda_laticaudata	laticauda_laticaudata	8630
+lat-chal	Coelacanth	latimeria_chalumnae	latimeria_chalumnae	7897
+lep-coro	Blue-crowned manakin	lepidothrix_coronata	lepidothrix_coronata	321398
+lep-ocul	Spotted gar	lepisosteus_oculatus	lepisosteus_oculatus	7918
+lep-leis	Leishan spiny toad	leptobrachium_leishanense	leptobrachium_leishanense	445787
+lon-stri-dome	Bengalese finch	lonchura_striata_domestica	lonchura_striata_domestica	40157
+lox-afri	Elephant	loxodonta_africana	loxodonta_africana	9785
+lyn-cana	Canada lynx	lynx_canadensis	lynx_canadensis	61383
+mac-fasc	Crab-eating macaque	macaca_fascicularis	macaca_fascicularis	9541
+mac-mula	Macaque	macaca_mulatta	macaca_mulatta	9544
+mac-neme	Pig-tailed macaque	macaca_nemestrina	macaca_nemestrina	9545
+mal-cyan-samu	Superb fairywren	malurus_cyaneus_samueli	malurus_cyaneus_samueli	2593467
+man-vite	Golden-collared manakin	manacus_vitellinus	manacus_vitellinus	328815
+man-leuc	Drill	mandrillus_leucophaeus	mandrillus_leucophaeus	9568
+mar-marm-marm	Alpine marmot	marmota_marmota_marmota	marmota_marmota_marmota	9994
+mas-arma	Zig-zag eel	mastacembelus_armatus	mastacembelus_armatus	205130
+may-zebr	Zebra mbuna	maylandia_zebra	maylandia_zebra	106582
+mel-gall	Turkey	meleagris_gallopavo	meleagris_gallopavo	9103
+mel-undu	Budgerigar	melopsittacus_undulatus	melopsittacus_undulatus	13146
+mer-ungu	Mongolian gerbil	meriones_unguiculatus	meriones_unguiculatus	10047
+mes-aura	Golden Hamster	mesocricetus_auratus	mesocricetus_auratus	10036
+mic-muri	Mouse Lemur	microcebus_murinus	microcebus_murinus	30608
+mic-ochr	Prairie vole	microtus_ochrogaster	microtus_ochrogaster	79684
+mol-mola	Ocean sunfish	mola_mola	mola_mola	94237
+mon-dome	Opossum	monodelphis_domestica	monodelphis_domestica	13616
+mon-mono	Narwhal	monodon_monoceros	monodon_monoceros	40151
+mon-albu	Swamp eel	monopterus_albus	monopterus_albus	43700
+mos-mosc	Siberian musk deer	moschus_moschiferus	moschus_moschiferus	68415
+mus-caro	Ryukyu mouse	mus_caroli	mus_caroli	10089
+mus-musc	Mouse	mus_musculus	mus_musculus	10090
+mus-musc-2	Mouse 129S1/SvImJ	mus_musculus_129s1svimj	mus_musculus_129s1svimj	10090
+mus-musc-aj	Mouse A/J	mus_musculus_aj	mus_musculus_aj	10090
+mus-musc-akrj	Mouse AKR/J	mus_musculus_akrj	mus_musculus_akrj	10090
+mus-musc-balb	Mouse BALB/cJ	mus_musculus_balbcj	mus_musculus_balbcj	10090
+mus-musc-3	Mouse C3H/HeJ	mus_musculus_c3hhej	mus_musculus_c3hhej	10090
+mus-musc-4	Mouse C57BL/6NJ	mus_musculus_c57bl6nj	mus_musculus_c57bl6nj	10090
+mus-musc-cast	Mouse CAST/EiJ	mus_musculus_casteij	mus_musculus_casteij	10091
+mus-musc-cbaj	Mouse CBA/J	mus_musculus_cbaj	mus_musculus_cbaj	10090
+mus-musc-5	Mouse DBA/2J	mus_musculus_dba2j	mus_musculus_dba2j	10090
+mus-musc-fvbn	Mouse FVB/NJ	mus_musculus_fvbnj	mus_musculus_fvbnj	10090
+mus-musc-lpj	Mouse LP/J	mus_musculus_lpj	mus_musculus_lpj	10090
+mus-musc-6	Mouse JF1/MsJ	mus_musculus_molossinusjf1msj	mus_musculus_molossinusjf1msj	57486
+mus-musc-nods	Mouse NOD/ShiLtJ	mus_musculus_nodshiltj	mus_musculus_nodshiltj	10090
+mus-musc-nzoh	Mouse NZO/HlLtJ	mus_musculus_nzohlltj	mus_musculus_nzohlltj	10090
+mus-musc-pwkp	Mouse PWK/PhJ	mus_musculus_pwkphj	mus_musculus_pwkphj	39442
+mus-musc-wsbe	Mouse WSB/EiJ	mus_musculus_wsbeij	mus_musculus_wsbeij	10092
+mus-paha	Shrew mouse	mus_pahari	mus_pahari	10093
+mus-spic	Steppe mouse	mus_spicilegus	mus_spicilegus	10103
+mus-spre	Western wild mouse	mus_spretus	mus_spretus	10096
+mus-puto-furo	Ferret	mustela_putorius_furo	mustela_putorius_furo	9669
+myo-luci	Microbat	myotis_lucifugus	myotis_lucifugus	59463
+myr-murd	Pinecone soldierfish	myripristis_murdjan	myripristis_murdjan	586833
+naj-naja	Indian cobra	naja_naja	naja_naja	35670
+nan-gali	Upper Galilee mountains blind mole rat	nannospalax_galili	nannospalax_galili	1026970
+neo-mela	Round goby	neogobius_melanostomus	neogobius_melanostomus	47308
+neo-bric	Lyretail cichlid	neolamprologus_brichardi	neolamprologus_brichardi	32507
+neo-viso	American mink	neovison_vison	neovison_vison	452646
+nom-leuc	Gibbon	nomascus_leucogenys	nomascus_leucogenys	61853
+not-euge	Wallaby	notamacropus_eugenii	notamacropus_eugenii	9315
+not-scut	Mainland tiger snake	notechis_scutatus	notechis_scutatus	8663
+not-furz	Turquoise killifish	nothobranchius_furzeri	nothobranchius_furzeri	105023
+not-perd	Chilean tinamou	nothoprocta_perdicaria	nothoprocta_perdicaria	30464
+num-mele	Helmeted guineafowl	numida_meleagris	numida_meleagris	8996
+och-prin	Pika	ochotona_princeps	ochotona_princeps	9978
+oct-degu	Degu	octodon_degus	octodon_degus	10160
+onc-kisu	Coho salmon	oncorhynchus_kisutch	oncorhynchus_kisutch	8019
+onc-myki	Rainbow trout	oncorhynchus_mykiss	oncorhynchus_mykiss	8022
+onc-tsha	Chinook salmon	oncorhynchus_tshawytscha	oncorhynchus_tshawytscha	74940
+ore-aure	Blue tilapia	oreochromis_aureus	oreochromis_aureus	47969
+ore-nilo	Nile tilapia	oreochromis_niloticus	oreochromis_niloticus	8128
+orn-anat	Platypus	ornithorhynchus_anatinus	ornithorhynchus_anatinus	9258
+ory-cuni	Rabbit	oryctolagus_cuniculus	oryctolagus_cuniculus	9986
+ory-java	Javanese ricefish	oryzias_javanicus	oryzias_javanicus	123683
+ory-lati	Japanese medaka HdrR	oryzias_latipes	oryzias_latipes	8090
+ory-lati-hni	Japanese medaka HNI	oryzias_latipes_hni	oryzias_latipes_hni	8090
+ory-lati-hsok	Japanese medaka HSOK	oryzias_latipes_hsok	oryzias_latipes_hsok	8090
+ory-mela	Indian medaka	oryzias_melastigma	oryzias_melastigma	30732
+ory-sine	Chinese medaka	oryzias_sinensis	oryzias_sinensis	183150
+oto-garn	Bushbaby	otolemur_garnettii	otolemur_garnettii	30611
+otu-suni	Oriental scops-owl	otus_sunia	otus_sunia	257818
+ovi-arie	Sheep	ovis_aries	ovis_aries	9940
+ovi-arie-2	Sheep - Hu	ovis_aries_gca011170295v1	ovis_aries_gca011170295v1	9940
+ovi-arie-3	Sheep - East friesian	ovis_aries_gca018804185v1	ovis_aries_gca018804185v1	9940
+ovi-arie-4	Sheep - Qiaoke	ovis_aries_gca022416685v1	ovis_aries_gca022416685v1	9940
+ovi-arie-5	Sheep - White dorper	ovis_aries_gca022416695v1	ovis_aries_gca022416695v1	9940
+ovi-arie-6	Sheep - Ujimqin	ovis_aries_gca022416755v1	ovis_aries_gca022416755v1	9940
+ovi-arie-7	Ovis aries (Texel sheep) - GCA_022416775.1	ovis_aries_gca022416775v1	ovis_aries_gca022416775v1	9940
+ovi-arie-8	Sheep - Polled Dorset	ovis_aries_gca022416915v1	ovis_aries_gca022416915v1	9940
+ovi-arie-9	Sheep - Chinese merino	ovis_aries_gca022432825v1	ovis_aries_gca022432825v1	9940
+ovi-arie-10	Sheep - Kermani	ovis_aries_gca022432835v1	ovis_aries_gca022432835v1	9940
+ovi-arie-11	Sheep - Romanov	ovis_aries_gca024222175v1	ovis_aries_gca024222175v1	9940
+ovi-arie-texe	Sheep - Texel	ovis_aries_texel	ovis_aries_texel	9940
+pan-pani	Bonobo	pan_paniscus	pan_paniscus	9597
+pan-trog	Chimpanzee	pan_troglodytes	pan_troglodytes	9598
+pan-leo	Lion	panthera_leo	panthera_leo	9689
+pan-pard	Leopard	panthera_pardus	panthera_pardus	9691
+pan-tigr-alta	Tiger	panthera_tigris_altaica	panthera_tigris_altaica	74533
+pap-anub	Olive baboon	papio_anubis	papio_anubis	9555
+par-rang	Indian glassy fish	parambassis_ranga	parambassis_ranga	210632
+par-king	Paramormyrops kingsleyae	paramormyrops_kingsleyae	paramormyrops_kingsleyae	1676925
+par-majo	Great Tit	parus_major	parus_major	9157
+pav-cris	Indian peafowl	pavo_cristatus	pavo_cristatus	9049
+pel-sine	Chinese softshell turtle	pelodiscus_sinensis	pelodiscus_sinensis	13735
+pel-cast	West African mud turtle	pelusios_castaneus	pelusios_castaneus	367368
+per-magn	Periophthalmus magnuspinnatus	periophthalmus_magnuspinnatus	periophthalmus_magnuspinnatus	409849
+per-mani-bair	Northern American deer mouse	peromyscus_maniculatus_bairdii	peromyscus_maniculatus_bairdii	230844
+pet-mari	Lamprey	petromyzon_marinus	petromyzon_marinus	7757
+pha-cine	Koala	phascolarctos_cinereus	phascolarctos_cinereus	38626
+pha-colc	Ring-necked pheasant	phasianus_colchicus	phasianus_colchicus	9054
+pho-sinu	Vaquita	phocoena_sinus	phocoena_sinus	42100
+phy-cato	Sperm whale	physeter_catodon	physeter_catodon	9755
+pil-teph	Ugandan red Colobus	piliocolobus_tephrosceles	piliocolobus_tephrosceles	591936
+pod-mura	Common wall lizard	podarcis_muralis	podarcis_muralis	64176
+poe-form	Amazon molly	poecilia_formosa	poecilia_formosa	48698
+poe-lati	Sailfin molly	poecilia_latipinna	poecilia_latipinna	48699
+poe-mexi	Shortfin molly	poecilia_mexicana	poecilia_mexicana	48701
+poe-reti	Guppy	poecilia_reticulata	poecilia_reticulata	8081
+pog-vitt	Central bearded dragon	pogona_vitticeps	pogona_vitticeps	103695
+pon-abel	Sumatran orangutan	pongo_abelii	pongo_abelii	9601
+pro-cape	Hyrax	procavia_capensis	procavia_capensis	9813
+pro-simu	Greater bamboo lemur	prolemur_simus	prolemur_simus	1328070
+pro-coqu	Coquerel's sifaka	propithecus_coquereli	propithecus_coquereli	379532
+pse-text	Eastern brown snake	pseudonaja_textilis	pseudonaja_textilis	8673
+pte-vamp	Megabat	pteropus_vampyrus	pteropus_vampyrus	132908
+pun-nyer	Makobe Island cichlid	pundamilia_nyererei	pundamilia_nyererei	303518
+pyg-natt	Red-bellied piranha	pygocentrus_nattereri	pygocentrus_nattereri	42514
+rat-norv	Norway rat - BN/NHsdMcwi	rattus_norvegicus	rattus_norvegicus	10116
+rat-norv-shrs	Rat - SHRSP/BbbUtx	rattus_norvegicus_shrspbbbutx	rattus_norvegicus_shrspbbbutx	10116
+rat-norv-shru	Rat - SHR/Utx RGD_8142385	rattus_norvegicus_shrutx	rattus_norvegicus_shrutx	10116
+rat-norv-wkyb	Rat - WKY/Bbb RGD_1581635	rattus_norvegicus_wkybbb	rattus_norvegicus_wkybbb	10116
+rhi-ferr	Greater horseshoe bat	rhinolophus_ferrumequinum	rhinolophus_ferrumequinum	59479
+rhi-biet	Black snub-nosed monkey	rhinopithecus_bieti	rhinopithecus_bieti	61621
+rhi-roxe	Golden snub-nosed monkey	rhinopithecus_roxellana	rhinopithecus_roxellana	61622
+sac-cere	Saccharomyces cerevisiae	saccharomyces_cerevisiae	saccharomyces_cerevisiae	559292
+sai-boli-boli	Bolivian squirrel monkey	saimiri_boliviensis_boliviensis	saimiri_boliviensis_boliviensis	39432
+sal-fasc	Jewelled blenny	salarias_fasciatus	salarias_fasciatus	181472
+sal-sala	Atlantic salmon	salmo_salar	salmo_salar	8030
+sal-sala-2	Atlantic salmon - North American Atlantic Salmon	salmo_salar_gca021399835v1	salmo_salar_gca021399835v1	8030
+sal-sala-3	Atlantic salmon - North American origin Brian	salmo_salar_gca923944775v1	salmo_salar_gca923944775v1	8030
+sal-sala-4	Atlantic salmon - European origin ALTA	salmo_salar_gca931346935v2	salmo_salar_gca931346935v2	8030
+sal-trut	Brown trout	salmo_trutta	salmo_trutta	8032
+sal-meri	Argentine black and white tegu	salvator_merianae	salvator_merianae	96440
+san-luci	Pike-perch	sander_lucioperca	sander_lucioperca	283035
+sar-harr	Tasmanian devil	sarcophilus_harrisii	sarcophilus_harrisii	9305
+sci-vulg	Eurasian red squirrel	sciurus_vulgaris	sciurus_vulgaris	55149
+scl-form	Asian bonytongue	scleropages_formosus	scleropages_formosus	113540
+sco-maxi	Turbot	scophthalmus_maximus	scophthalmus_maximus	52904
+ser-cana	Common canary	serinus_canaria	serinus_canaria	9135
+ser-dume	Greater amberjack	seriola_dumerili	seriola_dumerili	41447
+ser-lala-dors	Yellowtail amberjack	seriola_lalandi_dorsalis	seriola_lalandi_dorsalis	1841481
+sin-ansh	Blind barbel	sinocyclocheilus_anshuiensis	sinocyclocheilus_anshuiensis	1608454
+sin-grah	Golden-line barbel	sinocyclocheilus_grahami	sinocyclocheilus_grahami	75366
+sin-rhin	Horned golden-line barbel	sinocyclocheilus_rhinocerous	sinocyclocheilus_rhinocerous	307959
+sor-aran	Shrew	sorex_araneus	sorex_araneus	42254
+spa-aura	Gilthead seabream	sparus_aurata	sparus_aurata	8175
+spe-daur	Daurian ground squirrel	spermophilus_dauricus	spermophilus_dauricus	99837
+sph-orbi	Orbiculate cardinalfish	sphaeramia_orbicularis	sphaeramia_orbicularis	375764
+sph-punc	Tuatara	sphenodon_punctatus	sphenodon_punctatus	8508
+sta-rufi	Rufous-capped babbler	stachyris_ruficeps	stachyris_ruficeps	181631
+ste-part	Bicolor damselfish	stegastes_partitus	stegastes_partitus	144197
+str-habr	Kakapo	strigops_habroptila	strigops_habroptila	2489341
+str-occi-caur	Northern spotted owl	strix_occidentalis_caurina	strix_occidentalis_caurina	311401
+str-came-aust	African ostrich	struthio_camelus_australis	struthio_camelus_australis	441894
+sur-suri	Meerkat	suricata_suricatta	suricata_suricatta	37032
+sus-scro	Pig	sus_scrofa	sus_scrofa	9823
+sus-scro-bame	Pig - Bamei	sus_scrofa_bamei	sus_scrofa_bamei	9823
+sus-scro-berk	Pig - Berkshire	sus_scrofa_berkshire	sus_scrofa_berkshire	9823
+sus-scro-2	Pig - Bama miniature	sus_scrofa_gca007644095v1	sus_scrofa_gca007644095v1	9823
+sus-scro-3	Pig - Duroc	sus_scrofa_gca015776825v1	sus_scrofa_gca015776825v1	9823
+sus-scro-4	Pig - Meishan (GCA_017957985.1)	sus_scrofa_gca017957985v1	sus_scrofa_gca017957985v1	9825
+sus-scro-5	Pig - NIHS-2020	sus_scrofa_gca018555405v1	sus_scrofa_gca018555405v1	9823
+sus-scro-6	Pig - PB115	sus_scrofa_gca019290145v1	sus_scrofa_gca019290145v1	9823
+sus-scro-7	Pig - Ningxiang	sus_scrofa_gca020567905v1	sus_scrofa_gca020567905v1	9825
+sus-scro-8	Pig - euw1 (european wild boar)	sus_scrofa_gca021656055v1	sus_scrofa_gca021656055v1	9823
+sus-scro-9	Pig - Ossabaw miniature	sus_scrofa_gca024718415v1	sus_scrofa_gca024718415v1	9823
+sus-scro-hamp	Pig - Hampshire	sus_scrofa_hampshire	sus_scrofa_hampshire	9823
+sus-scro-jinh	Pig - Jinhua	sus_scrofa_jinhua	sus_scrofa_jinhua	9823
+sus-scro-land	Pig - Landrace	sus_scrofa_landrace	sus_scrofa_landrace	9823
+sus-scro-larg	Pig - Largewhite	sus_scrofa_largewhite	sus_scrofa_largewhite	9823
+sus-scro-meis	Pig - Meishan	sus_scrofa_meishan	sus_scrofa_meishan	9823
+sus-scro-piet	Pig - Pietrain	sus_scrofa_pietrain	sus_scrofa_pietrain	9823
+sus-scro-rong	Pig - Rongchang	sus_scrofa_rongchang	sus_scrofa_rongchang	9823
+sus-scro-tibe	Pig - Tibetan	sus_scrofa_tibetan	sus_scrofa_tibetan	9823
+sus-scro-usma	Pig USMARC	sus_scrofa_usmarc	sus_scrofa_usmarc	9823
+sus-scro-wuzh	Pig - Wuzhishan	sus_scrofa_wuzhishan	sus_scrofa_wuzhishan	9823
+tae-gutt	Zebra finch	taeniopygia_guttata	taeniopygia_guttata	59729
+tak-rubr	Fugu	takifugu_rubripes	takifugu_rubripes	31033
+ter-caro-triu	Three-toed box turtle	terrapene_carolina_triunguis	terrapene_carolina_triunguis	2587831
+tet-nigr	Tetraodon	tetraodon_nigroviridis	tetraodon_nigroviridis	99883
+the-gela	Gelada	theropithecus_gelada	theropithecus_gelada	9565
+tup-bela	Tree Shrew	tupaia_belangeri	tupaia_belangeri	37347
+tur-trun	Dolphin	tursiops_truncatus	tursiops_truncatus	9739
+uro-parr	Arctic ground squirrel	urocitellus_parryii	urocitellus_parryii	9999
+urs-amer	American black bear	ursus_americanus	ursus_americanus	9643
+urs-mari	Polar bear	ursus_maritimus	ursus_maritimus	29073
+urs-thib-thib	Asiatic black bear	ursus_thibetanus_thibetanus	ursus_thibetanus_thibetanus	441215
+var-komo	Komodo dragon	varanus_komodoensis	varanus_komodoensis	61221
+vic-paco	Alpaca	vicugna_pacos	vicugna_pacos	30538
+vom-ursi	Common wombat	vombatus_ursinus	vombatus_ursinus	29139
+vul-vulp	Red fox	vulpes_vulpes	vulpes_vulpes	9627
+xen-trop	Tropical clawed frog	xenopus_tropicalis	xenopus_tropicalis	8364
+xip-couc	Monterrey platyfish	xiphophorus_couchianus	xiphophorus_couchianus	32473
+xip-macu	Platyfish	xiphophorus_maculatus	xiphophorus_maculatus	8083
+zal-cali	California sea lion	zalophus_californianus	zalophus_californianus	9704
+zon-albi	White-throated sparrow	zonotrichia_albicollis	zonotrichia_albicollis	44394
+zos-late-mela	Silver-eye	zosterops_lateralis_melanops	zosterops_lateralis_melanops	1220523

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,18 @@ import pytest
 from ensembl_tui import _align as eti_align
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
+from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
 
 @pytest.fixture(scope="session")
 def DATA_DIR():
     return pathlib.Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def default_species_map():
+    return eti_species.make_species_map(None)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def small_install_path(small_path):
 
 @pytest.fixture(scope="session")
 def small_download_cfg(small_download_path):
-    return eti_config.read_config(small_download_path)
+    return eti_config.read_config(config_path=small_download_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/prep_tests_data/prep_ape_test.py
+++ b/tests/data/prep_tests_data/prep_ape_test.py
@@ -84,7 +84,7 @@ def drop_chrom(genome_dir: pathlib.Path, seqid: str = "22", check: bool = True):
 
 
 def copy_maf(cfg_path: pathlib.Path, dest_dir: pathlib.Path, seqid: str = "22"):
-    cfg = eti_config.read_config(cfg_path)
+    cfg = eti_config.read_config(config_path=cfg_path)
     align_path = cfg.staging_aligns / cfg.align_names[0]
     maf_file = min(align_path.glob(f"*.{seqid}*.maf.*"), key=lambda p: p.stat().st_size)
     dest_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -11,6 +11,7 @@ from ensembl_tui import _annotation as eti_annots
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _ingest_align as eti_ingest_align
+from ensembl_tui import _species as eti_species
 
 
 def make_gene_attr(records: list[dict]) -> eti_annots.GeneView:
@@ -498,6 +499,7 @@ def db_align(DATA_DIR, tmp_dir):
         align_names=[align_name],
         tree_names=[],
         homologies=True,
+        species_map=eti_species.make_species_map(None),
     )
     align_dir = cfg.staging_aligns / align_name
     align_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ def test_demo_config(tmp_dir):
     shutil.rmtree(tmp_dir)
 
 
+@pytest.mark.internet
 def test_demo_config_exists(tmp_dir):
     outdir = tmp_dir / "exported"
     outdir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_download_no_config():
     assert "No config" in r.output
 
 
+@pytest.mark.internet
 def test_demo_config(tmp_dir):
     """demo_config works correctly"""
     outdir = tmp_dir / "exported"
@@ -48,7 +49,7 @@ def test_demo_config(tmp_dir):
     assert r.exit_code == 0, r.output
     fnames = {f.name for f in outdir.iterdir()}
     assert "species.tsv" in fnames
-    assert len(fnames) == 2
+    assert len(fnames) == 3
     shutil.rmtree(tmp_dir)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,10 +32,9 @@ def test_installed_homologies():
 
 
 @pytest.fixture
-def installed_cfg_path(tmp_config, tmp_path):
-    config = eti_config.read_config(tmp_config)
-    outpath = eti_config.write_installed_cfg(config)
-    return outpath
+def installed_cfg_path(tmp_config):
+    config = eti_config.read_config(config_path=tmp_config)
+    return eti_config.write_installed_cfg(config)
 
 
 def test_read_installed(installed_cfg_path):
@@ -184,7 +183,7 @@ def cfg_just_genomes(empty_cfg):
 def test_read_config_compara_genomes(cfg_just_aligns):
     from ensembl_tui._species import Species
 
-    config = eti_config.read_config(cfg_just_aligns)
+    config = eti_config.read_config(config_path=cfg_just_aligns)
     site_map = eti_site_map.get_site_map(config.host)
     assert not config.species_dbs
     sp = eti_download.get_species_for_alignments(
@@ -202,6 +201,6 @@ def test_read_config_compara_genomes(cfg_just_aligns):
 def test_read_config_genomes(cfg_just_genomes):
     from ensembl_tui._species import Species
 
-    config = eti_config.read_config(cfg_just_genomes)
+    config = eti_config.read_config(config_path=cfg_just_genomes)
     expected = {Species.get_species_name(n) for n in COMMON_NAMES}
     assert set(config.species_dbs.keys()) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,27 +180,15 @@ def cfg_just_genomes(empty_cfg):
 
 @pytest.mark.internet
 @pytest.mark.timeout(10)
-def test_read_config_compara_genomes(cfg_just_aligns):
-    from ensembl_tui._species import Species
-
+def test_read_config_compara_genomes(cfg_just_aligns, default_species_map):
     config = eti_config.read_config(config_path=cfg_just_aligns)
-    site_map = eti_site_map.get_site_map(config.host)
-    assert not config.species_dbs
-    sp = eti_download.get_species_for_alignments(
-        host=config.host,
-        release=config.release,
-        align_names=config.align_names,
-        site_map=site_map,
-    )
-    expected = {Species.get_species_name(n) for n in COMMON_NAMES}
-    assert set(sp.keys()) == expected
+    expected = {default_species_map.get_genome_name(n) for n in COMMON_NAMES}
+    assert set(config.species_dbs.keys()) == expected
 
 
 @pytest.mark.internet
 @pytest.mark.timeout(10)
-def test_read_config_genomes(cfg_just_genomes):
-    from ensembl_tui._species import Species
-
+def test_read_config_genomes(cfg_just_genomes, default_species_map):
     config = eti_config.read_config(config_path=cfg_just_genomes)
-    expected = {Species.get_species_name(n) for n in COMMON_NAMES}
+    expected = {default_species_map.get_genome_name(n) for n in COMMON_NAMES}
     assert set(config.species_dbs.keys()) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,8 +5,6 @@ import pytest
 
 from ensembl_tui import _align as eti_align
 from ensembl_tui import _config as eti_config
-from ensembl_tui import _download as eti_download
-from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _util as eti_util
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,23 +10,32 @@ from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _util as eti_util
 
 
-def test_installed_genome():
+def test_installed_genome(default_species_map):
     cfg = eti_config.InstalledConfig(
-        release="110", install_path="abcd", software_versions={}
+        release="110",
+        install_path="abcd",
+        software_versions={},
+        species_map=default_species_map,
     )
     assert cfg.installed_genome("human") == pathlib.Path("abcd/genomes/homo_sapiens")
 
 
-def test_installed_aligns():
+def test_installed_aligns(default_species_map):
     cfg = eti_config.InstalledConfig(
-        release="110", install_path="abcd", software_versions={}
+        release="110",
+        install_path="abcd",
+        software_versions={},
+        species_map=default_species_map,
     )
     assert cfg.aligns_path == pathlib.Path("abcd/compara/aligns")
 
 
-def test_installed_homologies():
+def test_installed_homologies(default_species_map):
     cfg = eti_config.InstalledConfig(
-        release="110", install_path="abcd", software_versions={}
+        release="110",
+        install_path="abcd",
+        software_versions={},
+        species_map=default_species_map,
     )
     assert cfg.homologies_path == pathlib.Path("abcd/compara/homologies")
 
@@ -39,8 +48,8 @@ def installed_cfg_path(tmp_config):
 
 def test_read_installed(installed_cfg_path):
     got = eti_config.read_installed_cfg(installed_cfg_path)
-    assert str(got.installed_genome("human")) == str(
-        got.install_path / "genomes/homo_sapiens",
+    assert str(got.installed_genome("sac-cere")) == str(
+        got.install_path / "genomes/saccharomyces_cerevisiae",
     )
 
 
@@ -64,9 +73,12 @@ def test_read_installed_get_version_table(installed_cfg_path):
     assert table["ensembl_tui", "version"] == ensembl_tui.__version__
 
 
-def test_installed_config_hash():
+def test_installed_config_hash(default_species_map):
     ic = eti_config.InstalledConfig(
-        release="11", install_path="abcd", software_versions={}
+        release="11",
+        install_path="abcd",
+        software_versions={},
+        species_map=default_species_map,
     )
     assert hash(ic) == id(ic)
     v = {ic}
@@ -74,7 +86,7 @@ def test_installed_config_hash():
 
 
 @pytest.fixture
-def installed_aligns(tmp_path):
+def installed_aligns(tmp_path, default_species_map):
     align_dir = tmp_path / eti_config._COMPARA_NAME / eti_config._ALIGNS_NAME
     # make two alignment paths with similar names
     names = "10_primates.epo", "24_primates.epo_extended"
@@ -83,7 +95,10 @@ def installed_aligns(tmp_path):
         dirname.mkdir(parents=True, exist_ok=True)
         (dirname / f"align_blocks.{eti_align.ALIGN_STORE_SUFFIX}").open(mode="w")
     return eti_config.InstalledConfig(
-        release="11", install_path=tmp_path, software_versions={}
+        release="11",
+        install_path=tmp_path,
+        software_versions={},
+        species_map=default_species_map,
     )
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,7 +8,7 @@ from ensembl_tui import _mysql_core_attr as eti_db_attr
 @pytest.mark.internet
 @pytest.mark.timeout(10)
 def test_get_db_names(tmp_config):
-    cfg = eti_config.read_config(tmp_config)
+    cfg = eti_config.read_config(config_path=tmp_config)
     db_names = eti_download.get_core_db_dirnames(cfg)
     assert db_names == {
         "saccharomyces_cerevisiae": "pub/release-114/mysql/saccharomyces_cerevisiae_core_114_4",

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -1,4 +1,5 @@
 from ensembl_tui import _genome as eti_genome
+from ensembl_tui import _species as eti_species
 
 
 def test_get_gene_segments_limit(yeast_db):
@@ -38,7 +39,9 @@ def test_get_gene_table_for_species(yeast_db):
 def test_get_species_gene_summary(yeast_db):
     from cogent3.core.table import Table
 
-    got = eti_genome.get_species_gene_summary(annot_db=yeast_db)
+    got = eti_genome.get_species_gene_summary(
+        annot_db=yeast_db, species_map=eti_species.make_species_map(None)
+    )
     # we do not check values here, only the Type and that we have > 0 records
     assert isinstance(got, Table)
     assert len(got) > 0
@@ -48,7 +51,9 @@ def test_get_species_gene_summary(yeast_db):
 def test_get_species_repeat_summary(yeast_db):
     from cogent3.core.table import Table
 
-    got = eti_genome.get_species_repeat_summary(annot_db=yeast_db)
+    got = eti_genome.get_species_repeat_summary(
+        annot_db=yeast_db, species_map=eti_species.make_species_map(None)
+    )
     # we do not check values here, only the Type and that we have > 0 records
     assert isinstance(got, Table)
     assert len(got) > 0

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -155,7 +155,7 @@ def downloaded_cfg(tmp_downloaded):
 
 
 def test_write_parquet(downloaded_cfg):
-    cfg = eti_config.read_config(downloaded_cfg)
+    cfg = eti_config.read_config(config_path=downloaded_cfg)
     template_path = cfg.staging_template_path
     genome = "saccharomyces_cerevisiae"
     dump_path = cfg.staging_genomes / genome / "mysql" / "gene.txt.gz"
@@ -190,7 +190,7 @@ def test_install_features(yeast_db):
 # fail to import if directories or files are missing
 @pytest.fixture(params=[1, 2, 3])
 def invalid_downloaded_cfg(downloaded_cfg, request):
-    cfg = eti_config.read_config(downloaded_cfg)
+    cfg = eti_config.read_config(config_path=downloaded_cfg)
     genome = "saccharomyces_cerevisiae"
     genome_root = cfg.staging_genomes / genome
     if request.param == 1:
@@ -204,7 +204,7 @@ def invalid_downloaded_cfg(downloaded_cfg, request):
 
 
 def test_install_features_invalid(invalid_downloaded_cfg):
-    cfg = eti_config.read_config(invalid_downloaded_cfg)
+    cfg = eti_config.read_config(config_path=invalid_downloaded_cfg)
     with pytest.raises(FileNotFoundError):  # noqa: PT012
         app = eti_db_ingest.mysql_dump_to_parquet(config=cfg)
         # an exception during call in finding mysql file

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -1,15 +1,37 @@
 import pytest
 
-from ensembl_tui._site_map import get_site_map
+from ensembl_tui import _site_map as eti_smap
 
 
 @pytest.mark.parametrize("site", ("ftp.ensembl.org",))
 def test_correct_site(site):
-    smap = get_site_map(site)
+    smap = eti_smap.get_site_map(site)
     assert smap.site == site
 
 
 def test_standard_smp():
-    sm = get_site_map("ftp.ensembl.org")
+    sm = eti_smap.get_site_map("ftp.ensembl.org")
     assert sm.get_seqs_path("abcd") == "fasta/abcd/dna"
     assert sm.get_annotations_path("abcd") == "mysql/abcd"
+
+
+def test_get_site_map_names():
+    names = eti_smap.get_site_map_names()
+    assert "ftp.ensembl.org" in names
+    assert "ftp.ensemblgenomes.org" in names
+    assert "main" in names
+    assert "metazoa" in names
+
+
+def test_get_default_site_map_species():
+    smap = eti_smap.get_site_map("main")
+    assert smap.species_file_name == "species_EnsemblVertebrates.txt"
+
+
+@pytest.mark.parametrize("site", ("main", "metazoa"))
+def test_get_remote_path(site):
+    smap = eti_smap.get_site_map(site)
+    release = "62"
+    prefix = "pub" if site == "main" else f"pub/{site}"
+    expect = f"{prefix}/release-{release}"
+    assert smap.get_remote_release_path(release) == expect

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -112,6 +112,8 @@ def test_db_prefix_from_stableid_fail(invalid):
 def test_db_prefixes_from_stablesids(stableid, expect):
     got = Species.get_db_prefix_from_stableid(stableid)
     assert got == expect
+
+
 def test_make_unique_abbrevs():
     names = ["danaus_plexippus", "danaus_plexippus_gca018135715v1"]
     got = eti_species.make_unique_abbrevs(names)

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -1,117 +1,80 @@
 import pytest
 from cogent3.core.table import Table
 
-from ensembl_tui._species import Species
+from ensembl_tui import _species as eti_species
 
 
-def test_get_name_type():
+@pytest.fixture(scope="module")
+def species():
+    return eti_species.make_species_map(species_path=None)
+
+
+def test_get_name_type(species):
     """should return the (latin|common) name given a latin, common or ensembl
     db prefix names"""
-    assert Species.get_species_name("human") == "Homo sapiens"
-    assert Species.get_species_name("homo_sapiens") == "Homo sapiens"
+    assert species.get_species_name("human") == "Homo sapiens"
+    assert species.get_species_name("homo_sapiens") == "Homo sapiens"
     assert (
-        Species.get_species_name("canis_lupus_familiaris") == "Canis lupus familiaris"
+        species.get_species_name("canis_lupus_familiaris") == "Canis lupus familiaris"
     )
-    assert Species.get_common_name("Mus musculus") == "Mouse"
-    assert Species.get_common_name("mus_musculus") == "Mouse"
+    assert species.get_common_name("Mus musculus") == "mouse"
+    assert species.get_common_name("mus_musculus") == "mouse"
 
 
-def test_get_ensembl_format():
+def test_get_ensembl_format(species):
     """should take common or latin names and return the corresponding
     ensembl db prefix"""
-    assert Species.get_ensembl_db_prefix("human") == "homo_sapiens"
-    assert Species.get_ensembl_db_prefix("mouse") == "mus_musculus"
-    assert Species.get_ensembl_db_prefix("Mus musculus") == "mus_musculus"
+    assert species.get_ensembl_db_prefix("human") == "homo_sapiens"
+    assert species.get_ensembl_db_prefix("mouse") == "mus_musculus"
+    assert species.get_ensembl_db_prefix("Mus musculus") == "mus_musculus"
     assert (
-        Species.get_ensembl_db_prefix("Canis lupus familiaris")
+        species.get_ensembl_db_prefix("Canis lupus familiaris")
         == "canis_lupus_familiaris"
     )
 
 
-def test_add_new_species():
-    """should correctly add a new species/common combination and infer the
-    correct ensembl prefix"""
-    species_name, common_name = "Otolemur garnettii", "Bushbaby"
-    Species.amend_species(species_name, common_name)
-    assert Species.get_species_name(species_name) == species_name
-    assert Species.get_species_name("Bushbaby") == species_name
-    assert Species.get_species_name(common_name) == species_name
-    assert Species.get_common_name(species_name) == common_name
-    assert Species.get_common_name("Bushbaby") == common_name
-    assert Species.get_ensembl_db_prefix("Bushbaby") == "otolemur_garnettii"
-    assert Species.get_ensembl_db_prefix(species_name) == "otolemur_garnettii"
-    assert Species.get_ensembl_db_prefix(common_name) == "otolemur_garnettii"
+def test_get_genome_name(species):
+    got = species.get_genome_name("Sheep - Polled Dorset")
+    assert got.startswith("ovis_aries")
 
 
-def test_amend_existing():
-    """should correctly amend an existing species"""
-    species_name = "Ochotona princeps"
-    common_name1 = "american pika"
-    common_name2 = "pika"
-    ensembl_pref = "ochotona_princeps"
-    Species.amend_species(species_name, common_name1)
-    assert Species.get_common_name(species_name) == common_name1
-    Species.amend_species(species_name, common_name2)
-    assert Species.get_species_name(common_name2) == species_name
-    assert Species.get_species_name(ensembl_pref) == species_name
-    assert Species.get_common_name(species_name) == common_name2
-    assert Species.get_common_name(ensembl_pref) == common_name2
-    assert Species.get_ensembl_db_prefix(species_name) == ensembl_pref
-    assert Species.get_ensembl_db_prefix(common_name2) == ensembl_pref
+@pytest.mark.parametrize("arg", ["Human", "human", "homo_sapiens", "Homo sapiens"])
+def test_get_abreviation(arg, species):
+    table = species.to_table()
+    human_identifiers = table.filtered(
+        lambda x: x == "human", columns="common_name"
+    ).columns.to_dict()
+    expect = human_identifiers.pop("abbrev")[0]
+    got = species.get_abbreviation(arg)
+    assert got == expect
+    got = species.get_abbreviation(expect)
+    assert got == expect
 
 
-def test_lookup_raises():
-    """setting level  to raise should create exceptions"""
-    with pytest.raises(ValueError):
-        Species.get_species_name("failme", level="raise")
-    with pytest.raises(ValueError):
-        Species.get_common_name("failme", level="raise")
-    with pytest.raises(ValueError):
-        Species.get_ensembl_db_prefix("failme")
+def test_lookup_raises(species):
+    """setting level to raise should create exceptions"""
+    with pytest.raises(ValueError):  # noqa: PT011
+        species.get_species_name("failme", level="raise")
+    with pytest.raises(ValueError):  # noqa: PT011
+        species.get_common_name("failme", level="raise")
+    with pytest.raises(ValueError):  # noqa: PT011
+        species.get_ensembl_db_prefix("failme", level="raise")
 
 
-def test_to_table():
+def test_to_table(species):
     """returns a table object"""
-    table = Species.to_table()
+    table = species.to_table()
     assert isinstance(table, Table)
     assert table.shape[0] > 20
-    assert table.shape[1] == 3
+    assert table.shape[1] == len(eti_species.TABLE_COLUMNS)
 
 
 @pytest.mark.parametrize(
     "name",
-    ("Human", "human", "Anas platyrhynchos", "Dog - Basenji"),
+    ["Human", "human", "Anas platyrhynchos", "Dog - Basenji"],
 )
-def test_contains(name):
-    assert name in Species
-
-
-@pytest.mark.parametrize("feature_prefix", ("E", "FM", "G", "GT", "P", "R", "T"))
-def test_db_prefix_from_stableid(feature_prefix):
-    stableid = f"ENSPTI{feature_prefix}00000025624"
-    expect = "panthera_tigris_altaica"
-    got = Species.get_db_prefix_from_stableid(stableid)
-    assert got == expect
-
-
-@pytest.mark.parametrize("invalid", ("blah", "ENSPTIX012345678911"))
-def test_db_prefix_from_stableid_fail(invalid):
-    with pytest.raises(ValueError):
-        Species.get_db_prefix_from_stableid(invalid)
-
-
-@pytest.mark.parametrize(
-    "stableid,expect",
-    (
-        ("ENSCSAG00000025624", "chlorocebus_sabaeus"),
-        ("ENSGGOG00000041075", "gorilla_gorilla"),
-        ("ENSPPAG00000009915", "pan_paniscus"),
-        ("ENSG00000278672", "homo_sapiens"),
-    ),
-)
-def test_db_prefixes_from_stablesids(stableid, expect):
-    got = Species.get_db_prefix_from_stableid(stableid)
-    assert got == expect
+def test_contains(name, species):
+    assert name in species
 
 
 def test_make_unique_abbrevs():

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -90,6 +90,37 @@ def test_make_unique_abbrevs():
     assert got == dict(zip(names, ["dan-plex", "dan-plex-2"], strict=False))
 
 
+def test_for_storage(species):
+    d = species.for_storage()
+    # first value in header should be the genome name
+    delim = "\t"
+    header = d["header"].split(delim)
+    assert header[0] == "genome_name"
+    assert set(header) == set(eti_species.TABLE_COLUMNS)
+    human_data = dict(
+        zip(
+            header,
+            ["homo_sapiens", *d["homo_sapiens"].split(delim)],
+            strict=True,
+        )
+    )
+    expect = {
+        "abbrev": "hom-sapi",
+        "genome_name": "homo_sapiens",
+        "common_name": "human",
+        "db_prefix": "homo_sapiens",
+    }
+    assert human_data == expect
+
+
+def test_from_storage(species):
+    table = species.to_table().sorted(columns="abbrev")
+    d = species.for_storage()
+    inflated = species.from_storage(d)
+    got = inflated.to_table().sorted(columns="abbrev")
+    assert got.to_list() == table.to_list()
+
+
 def test_get_subset(species):
     """should take common or latin names and return the corresponding
     ensembl db prefix"""

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -21,6 +21,13 @@ def test_get_name_type(species):
     assert species.get_common_name("mus_musculus") == "mouse"
 
 
+def test_get_species_from_common(species):
+    common = "Microbat"
+    assert common in species
+    got = species.get_species_name(common)
+    assert got == "Myotis lucifugus"
+
+
 def test_get_ensembl_format(species):
     """should take common or latin names and return the corresponding
     ensembl db prefix"""

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -88,3 +88,19 @@ def test_make_unique_abbrevs():
     names = ["danaus_plexippus", "danaus_plexippus_gca018135715v1"]
     got = eti_species.make_unique_abbrevs(names)
     assert got == dict(zip(names, ["dan-plex", "dan-plex-2"], strict=False))
+
+
+def test_get_subset(species):
+    """should take common or latin names and return the corresponding
+    ensembl db prefix"""
+    subset = species.get_subset(["human", "Mus musculus", "canis_lupus_familiaris"])
+    assert subset.to_table().shape[0] == 3
+    got = subset.get_abbreviation("saccharomyces_cerevisiae", level="ignore")
+    assert got is None
+
+
+def test_get_subset_invalid(species):
+    """should take common or latin names and return the corresponding
+    ensembl db prefix"""
+    with pytest.raises(ValueError):  # noqa: PT011
+        species.get_subset(["does not exist"])

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -112,3 +112,7 @@ def test_db_prefix_from_stableid_fail(invalid):
 def test_db_prefixes_from_stablesids(stableid, expect):
     got = Species.get_db_prefix_from_stableid(stableid)
     assert got == expect
+def test_make_unique_abbrevs():
+    names = ["danaus_plexippus", "danaus_plexippus_gca018135715v1"]
+    got = eti_species.make_unique_abbrevs(names)
+    assert got == dict(zip(names, ["dan-plex", "dan-plex-2"], strict=False))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -159,19 +159,6 @@ def test_missing_match_align_tree(tmp_config):
         eti_util.trees_for_aligns(aligns, trees)
 
 
-def test_config_update_invalid_species(tmp_config):
-    config = eti_config.read_config(config_path=tmp_config)
-    with pytest.raises(ValueError):
-        config.update_species({"Micro bat": ["core"]})
-
-
-def test_config_update_species(tmp_config):
-    config = eti_config.read_config(config_path=tmp_config)
-    config.update_species({"Human": ["core"]})
-    assert len(list(config.db_names)) == 2
-    assert set(config.db_names) == {"homo_sapiens", "saccharomyces_cerevisiae"}
-
-
 @pytest.mark.internet
 @pytest.mark.timeout(10)
 def test_cfg_to_dict(just_compara_cfg):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,7 +22,7 @@ def compara_cfg(tmp_config):
 
 
 def test_parse_config(compara_cfg):
-    cfg = eti_config.read_config(compara_cfg)
+    cfg = eti_config.read_config(config_path=compara_cfg)
     assert set(cfg.align_names) == {"17_sauropsids.epc", "10_primates.epo"}
 
 
@@ -53,7 +53,7 @@ def gorilla_cfg(tmp_config):
 
 def test_parse_config_gorilla(gorilla_cfg):
     # Gorilla has two synonyms, we need only one
-    cfg = eti_config.read_config(gorilla_cfg)
+    cfg = eti_config.read_config(config_path=gorilla_cfg)
     num_gorilla = sum(1 for k in cfg.species_dbs if "gorilla" in k)
     assert num_gorilla == 1
 
@@ -108,13 +108,13 @@ def just_compara_cfg(tmp_config):
 @pytest.mark.timeout(10)
 def test_just_compara(just_compara_cfg):
     # get species names from the alignment ref tree
-    cfg = eti_config.read_config(just_compara_cfg)
+    cfg = eti_config.read_config(config_path=just_compara_cfg)
     # 10 primates i the alignments, so we should have 10 db's
     assert len(cfg.species_dbs) == 10
 
 
 def test_write_read_installed_config(tmp_config):
-    config = eti_config.read_config(tmp_config)
+    config = eti_config.read_config(config_path=tmp_config)
     cfg_path = eti_config.write_installed_cfg(config)
     icfg = eti_config.read_installed_cfg(cfg_path.parent)
     assert icfg.release == config.release
@@ -160,13 +160,13 @@ def test_missing_match_align_tree(tmp_config):
 
 
 def test_config_update_invalid_species(tmp_config):
-    config = eti_config.read_config(tmp_config)
+    config = eti_config.read_config(config_path=tmp_config)
     with pytest.raises(ValueError):
         config.update_species({"Micro bat": ["core"]})
 
 
 def test_config_update_species(tmp_config):
-    config = eti_config.read_config(tmp_config)
+    config = eti_config.read_config(config_path=tmp_config)
     config.update_species({"Human": ["core"]})
     assert len(list(config.db_names)) == 2
     assert set(config.db_names) == {"homo_sapiens", "saccharomyces_cerevisiae"}
@@ -175,12 +175,12 @@ def test_config_update_species(tmp_config):
 @pytest.mark.internet
 @pytest.mark.timeout(10)
 def test_cfg_to_dict(just_compara_cfg):
-    cfg = eti_config.read_config(just_compara_cfg)
+    cfg = eti_config.read_config(config_path=just_compara_cfg)
     data = cfg.to_dict()
     cfg.write()
     path = cfg.staging_path / eti_config.DOWNLOADED_CONFIG_NAME
     assert path.exists()
-    got_cfg = eti_config.read_config(path)
+    got_cfg = eti_config.read_config(config_path=path)
     assert got_cfg.to_dict() == data
 
 


### PR DESCRIPTION
## Summary by Sourcery

Provide support for retrieving and exporting Ensembl species information by adding species table download and parsing, extending site map configurations, and integrating a new CLI option.

New Features:
- Add download_species_table to fetch and parse Ensembl species files from FTP.
- Add --site CLI option and integrate species-full.tsv export into demo_config command.
- Extend SiteMap with species_file_name attribute and register vertebrates and metazoa site maps with corresponding species files.

Enhancements:
- Implement make_unique_abbrevs to generate unique species abbreviations.
- Add get_site_map_names to list available Ensembl site map domains.

Tests:
- Add test for make_unique_abbrevs.
- Update demo_config CLI test to expect species-full.tsv in the output.