### PR TITLE
Increase test coverage

### DIFF
--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -30,16 +30,6 @@ def valid_seq_file(name: str) -> bool:
     return _valid_seq.search(name) is not None
 
 
-class valid_gff3_file:  # noqa: N801
-    """whole genome gff3"""
-
-    def __init__(self, release: str) -> None:
-        self._valid = re.compile(f"([.]{release}[.]gff3[.]gz|README|CHECKSUMS)")
-
-    def __call__(self, name: str) -> bool:
-        return self._valid.search(name) is not None
-
-
 def _remove_tmpdirs(path: eti_util.PathType) -> None:
     """delete any tmp dirs left over from unsuccessful runs"""
     tmpdirs = [p for p in path.glob("tmp*") if p.is_dir()]
@@ -159,7 +149,6 @@ def download_species(
             description=msg,
         )
 
-    patterns = {"fasta": valid_seq_file, "gff3": valid_gff3_file(config.release)}
     for key in config.species_dbs:
         db_prefix = config.species_map.get_ensembl_db_prefix(key)
         local_root = config.staging_genomes / db_prefix
@@ -168,7 +157,7 @@ def download_species(
         remote = site_map.get_seqs_path(db_prefix)
         remote_dir = remote_template.format(remote)
         remote_paths = list(
-            eti_ftp.listdir(config.host, path=remote_dir, pattern=patterns["fasta"]),
+            eti_ftp.listdir(config.host, path=remote_dir, pattern=valid_seq_file),
         )
         if verbose:
             eti_util.print_colour(text=f"{remote_paths=}", colour="yellow")

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -16,7 +16,7 @@ from ensembl_tui import _site_map as eti_site_map
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from cogent3.core.table import Table
     from cogent3.core.tree import PhyloNode
 

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -352,7 +352,7 @@ def download_ensembl_tree(
     if site_map.trees_path is None:
         return None
     url = f"https://{host}/{site_map.remote_path}/release-{release}/{site_map.trees_path}/{tree_fname}"
-    return cogent3.load_tree(url)
+    return cogent3.load_tree(url, underscore_unmunge=False)
 
 
 def get_ensembl_trees(

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -7,7 +7,7 @@ from cogent3.core.tree import PhyloNode
 
 from ensembl_tui import _util as eti_util
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from cogent3.core.table import Table
 
 SPECIES_NAME = "species.tsv"
@@ -44,9 +44,6 @@ def _genome_name_to_species_name(genome_name: str) -> str:
 
 def _latin_to_abbrev(genome_to_abrv: dict[str, str], latin_name: str) -> str | None:
     """convert a latin name to a abbreviation"""
-    if " " not in latin_name:
-        return None
-
     latin_name = latin_name.replace(" ", "_")
     found = []
     for genome_name, abrv in genome_to_abrv.items():
@@ -57,8 +54,7 @@ def _latin_to_abbrev(genome_to_abrv: dict[str, str], latin_name: str) -> str | N
     if len(found) == 1:
         return found[0]
 
-    msg = f"matches to {latin_name!r} {found} != 1"
-    raise ValueError(msg)
+    return None
 
 
 class SpeciesNameMap:
@@ -246,7 +242,7 @@ def species_from_ensembl_tree(
         for j in range(len(name_fields) + 1, 1, -1):
             n = "_".join(name_fields[:j])
             if n in species_map:
-                selected_species[species_map.get_genome_name(n)] = n
+                selected_species[species_map.get_genome_name(n)] = tip_name
                 break
         else:
             msg = f"cannot establish species for {'_'.join(name_fields)}"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -274,7 +274,7 @@ def test_get_ids_for_biotype2(yeast_db):
     features = list(yeast_db.get_ids_for_biotype(biotype="rRNA", limit=10))
     assert len(features) == 10
 
-
+@pytest.mark.slow
 def test_get_ids_for_biotype_seqid(yeast_db, yeast):
     stable_ids = list(
         yeast_db.get_ids_for_biotype(biotype="protein_coding", seqid="III"),

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -274,6 +274,7 @@ def test_get_ids_for_biotype2(yeast_db):
     features = list(yeast_db.get_ids_for_biotype(biotype="rRNA", limit=10))
     assert len(features) == 10
 
+
 @pytest.mark.slow
 def test_get_ids_for_biotype_seqid(yeast_db, yeast):
     stable_ids = list(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,6 +3,7 @@ import pytest
 import ensembl_tui._config as eti_config
 import ensembl_tui._download as eti_download
 from ensembl_tui import _mysql_core_attr as eti_db_attr
+from ensembl_tui import _site_map as eti_smap
 
 
 @pytest.mark.internet
@@ -21,3 +22,19 @@ def test_make_dumpfiles():
     assert {
         n.split(".")[0] for n in table_names - {"CHECKSUMS"}
     } == eti_db_attr.get_all_tables()
+
+
+@pytest.mark.internet
+@pytest.mark.timeout(10)
+def test_download_tree():
+    from cogent3.core.tree import PhyloNode
+
+    smap = eti_smap.get_site_map("main")
+    got = eti_download.download_ensembl_tree(
+        host=smap.site,
+        site_map=smap,
+        release="115",
+        tree_fname="10_primates_EPO_default.nh",
+    )
+
+    assert isinstance(got, PhyloNode)

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -1,6 +1,9 @@
 import pytest
+from cogent3 import make_tree
 from cogent3.core.table import Table
 
+from ensembl_tui import _download as eti_download
+from ensembl_tui import _site_map as eti_smap
 from ensembl_tui import _species as eti_species
 
 
@@ -40,9 +43,19 @@ def test_get_ensembl_format(species):
     )
 
 
+def test_get_ensembl_prefix_invalid(species):
+    assert species.get_ensembl_db_prefix(1) is None
+    assert species.get_ensembl_db_prefix("not present") is None
+
+
 def test_get_genome_name(species):
     got = species.get_genome_name("Sheep - Polled Dorset")
     assert got.startswith("ovis_aries")
+
+
+def test_get_genome_name_invalid(species):
+    assert not species.get_genome_name(1)
+    assert not species.get_genome_name("not present")
 
 
 @pytest.mark.parametrize("arg", ["Human", "human", "homo_sapiens", "Homo sapiens"])
@@ -66,6 +79,20 @@ def test_lookup_raises(species):
         species.get_common_name("failme", level="raise")
     with pytest.raises(ValueError):  # noqa: PT011
         species.get_ensembl_db_prefix("failme", level="raise")
+
+
+def test_lookup_warns(species, capsys):
+    """setting level to warn should create warnings"""
+    species.get_species_name("failme", level="warn")
+    captured = capsys.readouterr()
+    assert captured.out.startswith("WARN:")
+
+
+def test_lookup_latin(species):
+    # lonchura_striata_domestica
+    query = "lonchura striata"
+    got = species.get_abbreviation(query, level="raise")
+    assert got == "lon-stri-dome"
 
 
 def test_to_table(species):
@@ -135,3 +162,30 @@ def test_get_subset_invalid(species):
     ensembl db prefix"""
     with pytest.raises(ValueError):  # noqa: PT011
         species.get_subset(["does not exist"])
+
+
+def test_spec_map_dunder(species):
+    assert repr(species)
+    assert str(species)
+    assert species._repr_html_()
+
+
+@pytest.mark.internet
+@pytest.mark.timeout(10)
+def test_species_from_tree(species):
+    smap = eti_smap.get_site_map("main")
+    ens_tree = eti_download.download_ensembl_tree(
+        host=smap.site,
+        site_map=smap,
+        release="115",
+        tree_fname="10_primates_EPO_default.nh",
+    )
+
+    genome_tip_map = eti_species.species_from_ensembl_tree(ens_tree, species)
+    assert len(genome_tip_map) == len(ens_tree.get_tip_names())
+
+
+def test_species_from_invalid_tree(species):
+    tree = make_tree(tip_names=["a_b_c_d", "e_f_g_h", "i_j_k_l"])
+    with pytest.raises(ValueError):  # noqa: PT011
+        _ = eti_species.species_from_ensembl_tree(tree, species)


### PR DESCRIPTION
## Summary by Sourcery

Expand test coverage for species lookup and download utilities and refine error handling and mapping logic.

Bug Fixes:
- Preserve underscores when loading phylogenetic trees by disabling unmunge in cogent3.load_tree
- Correct species_from_ensembl_tree mapping to use original tip names instead of truncated keys

Enhancements:
- Remove deprecated valid_gff3_file validator and unify sequence file filtering with valid_seq_file
- Simplify latin name to abbreviation conversion to return None for non-unique or invalid names
- Exclude TYPE_CHECKING blocks from coverage measurement with pragma:no cover

Tests:
- Add tests for invalid inputs and warning levels in species getter methods (get_ensembl_db_prefix, get_genome_name, get_abbreviation, get_species_name)
- Add tests for representation methods (__repr__, __str__, _repr_html__) on SpeciesNameMap
- Add tests for species_from_ensembl_tree with valid and invalid trees under internet and timeout marks
- Add test for download_ensembl_tree to verify PhyloNode loading
- Mark test_get_ids_for_biotype_seqid as slow