### PR TITLE
Update for Ensembl release 115

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-small-v2-${{ hashFiles('tests/data/small-115.zip') }}
+          key: ${{ runner.os }}-small-v3-${{ hashFiles('tests/data/small-115.zip') }}
           restore-keys: |
-            ${{ runner.os }}-small-v2-
+            ${{ runner.os }}-small-v3-
 
       - name: Check cache status
         run: |
@@ -46,9 +46,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-apes-v2-${{ hashFiles('tests/data/apes-115.zip') }}
+          key: ${{ runner.os }}-apes-v3-${{ hashFiles('tests/data/apes-115.zip') }}
           restore-keys: |
-            ${{ runner.os }}-apes-v2-
+            ${{ runner.os }}-apes-v3-
 
       - name: Check apes data cache status
         run: |
@@ -64,9 +64,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-apes-maf-v2-${{ hashFiles('tests/data/apes-115-maf.zip') }}
+          key: ${{ runner.os }}-apes-maf-v3-${{ hashFiles('tests/data/apes-115-maf.zip') }}
           restore-keys: |
-            ${{ runner.os }}-apes-maf-v2-
+            ${{ runner.os }}-apes-maf-v3-
 
       - name: Check apes maf cache status
         run: |

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-small-v1-${{ hashFiles('tests/data/small-114.zip') }}
+          key: ${{ runner.os }}-small-v2-${{ hashFiles('tests/data/small-115.zip') }}
           restore-keys: |
-            ${{ runner.os }}-small-v1-
+            ${{ runner.os }}-small-v2-
 
       - name: Check cache status
         run: |
@@ -39,16 +39,16 @@ jobs:
       - name: Download small data file
         if: steps.cache-small-data.outputs.cache-hit != 'true'
         run: |
-          curl -L -o tests/data/small-114.zip "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+          curl -L -o tests/data/small-115.zip "https://www.dropbox.com/scl/fi/cknsuhd6k8t6fjn1odzog/small-115.zip?rlkey=zkacmbhx4ssf4v80d78dd9uql&dl=1"
 
       - name: Set up apes installed cache
         id: cache-apes-data
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-apes-v1-${{ hashFiles('tests/data/apes-114.zip') }}
+          key: ${{ runner.os }}-apes-v2-${{ hashFiles('tests/data/apes-115.zip') }}
           restore-keys: |
-            ${{ runner.os }}-apes-v1-
+            ${{ runner.os }}-apes-v2-
 
       - name: Check apes data cache status
         run: |
@@ -57,16 +57,16 @@ jobs:
       - name: Download apes installation data file
         if: steps.cache-apes-data.outputs.cache-hit != 'true'
         run: |
-          curl -L -o tests/data/apes-114.zip "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
+          curl -L -o tests/data/apes-115.zip "https://www.dropbox.com/scl/fi/h6kd0rlntvyzcb6d485fa/apes-115.zip?rlkey=4hza000j7btue6qwnxvnid5gb&dl=1"
 
       - name: Set up apes maf cache
         id: cache-apes-data-maf
         uses: actions/cache@v3
         with:
           path: tests/data
-          key: ${{ runner.os }}-apes-maf-v1-${{ hashFiles('tests/data/apes-114-maf.zip') }}
+          key: ${{ runner.os }}-apes-maf-v2-${{ hashFiles('tests/data/apes-115-maf.zip') }}
           restore-keys: |
-            ${{ runner.os }}-apes-maf-v1-
+            ${{ runner.os }}-apes-maf-v2-
 
       - name: Check apes maf cache status
         run: |
@@ -75,14 +75,14 @@ jobs:
       - name: Download apes maf data file
         if: steps.cache-apes-data-maf.outputs.cache-hit != 'true'
         run: |
-          curl -L -o tests/data/apes-114-maf.zip "https://www.dropbox.com/scl/fi/9kc57hitzhwwifq35je8l/apes-114-maf.zip?rlkey=mxeytmuv672cpfar7iirh7emm&dl=1"
+          curl -L -o tests/data/apes-115-maf.zip "https://www.dropbox.com/scl/fi/2wmle5kzjdqralppvddsr/apes-115-maf.zip?rlkey=u1hbfo0jqwhfkfukntgx5tbfn&dl=1"
 
       - name: Unzip data files
         run: |
           cd tests/data
-          unzip -o -q small-114.zip
-          unzip -o -q apes-114.zip
-          unzip -o -q apes-114-maf.zip
+          unzip -o -q small-115.zip
+          unzip -o -q apes-115.zip
+          unzip -o -q apes-115-maf.zip
 
       - uses: "actions/setup-python@v5"
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["biology", "genomics", "evolution", "bioinformatics"]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
-dependencies = ["blosc2",
+dependencies = [
         "click",
         "cogent3==2025.7.10a5",
         "cogent3-h5seqs==0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
         "click",
-        "cogent3==2025.7.10a5",
-        "cogent3-h5seqs==0.5.0",
+        "cogent3==2025.9.8a3",
+        "cogent3-h5seqs==0.7.0",
         "duckdb",
         "numba",
         "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
         "duckdb",
         "numba",
         "numpy",
+        "polars",
+        "pyarrow",
         "rich",
         "scitrack",
         "typing_extensions",
@@ -57,7 +59,6 @@ eti = "ensembl_tui.cli:main"
 
 [project.optional-dependencies]
 test = [
-    "pandas",
     "pytest",
     "pytest-cov",
     "pytest-timeout",

--- a/src/ensembl_tui/_align.py
+++ b/src/ensembl_tui/_align.py
@@ -203,7 +203,7 @@ class AlignDb(eti_storage.DuckdbParquetBase):
         return self.conn.sql(f"SELECT COUNT(*) from {self._tables[0]}").fetchone()[0]
 
     def close(self) -> None:
-        """closes duckdb and h5py storage"""
+        """closes duckdb storage"""
         self.conn.close()
 
 

--- a/src/ensembl_tui/_genome.py
+++ b/src/ensembl_tui/_genome.py
@@ -62,13 +62,15 @@ class fasta_to_hdf5:  # noqa: N801
         )
         src_dir = src_dir / "fasta"
         for path in src_dir.glob("*.fa.gz"):
-            for seqid, seq in iter_fasta_records(
-                path,
-                converter=bytes_to_array,
-                label_to_name=self.label_to_name,
-            ):
-                seq_store.add_seqs({seqid: seq}, force_unique_keys=False)
-                del seq
+            seqs = dict(
+                iter_fasta_records(
+                    path,
+                    converter=bytes_to_array,
+                    label_to_name=self.label_to_name,
+                )
+            )
+            seq_store.add_seqs(seqs, force_unique_keys=False)
+            del seqs
 
         seq_store.close()
 

--- a/src/ensembl_tui/_ingest_annotation.py
+++ b/src/ensembl_tui/_ingest_annotation.py
@@ -74,7 +74,7 @@ def migrate_schema(con: duckdb.DuckDBPyConnection, table_name: str) -> None:
     FROM information_schema.columns
     WHERE table_name = '{table_name}'
     AND column_name LIKE '%strand'"""
-    names = con.sql(sql).to_df()
+    names = con.sql(sql).pl()
     names_types = zip(
         names["column_name"].to_list(),
         names["data_type"].to_list(),
@@ -96,7 +96,7 @@ def migrate_schema(con: duckdb.DuckDBPyConnection, table_name: str) -> None:
     WHERE table_name = '{table_name}'
     AND data_type = 'TIMESTAMP';
     """
-    names = con.sql(sql).to_df()
+    names = con.sql(sql).pl()
     names_types = zip(
         names["column_name"].to_list(),
         names["data_type"].to_list(),

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -13,8 +13,6 @@ from collections.abc import Callable, Hashable
 from hashlib import md5
 from typing import IO
 
-import blosc2
-import hdf5plugin
 import numba
 import numpy
 from cogent3.app.composable import define_app
@@ -38,12 +36,6 @@ except (NotImplementedError, ImportError):
     keep_running = contextlib.nullcontext
 
 CWD = pathlib.Path.cwd()
-
-HDF5_BLOSC2_KWARGS = hdf5plugin.Blosc2(
-    cname="blosclz",
-    clevel=9,
-    filters=hdf5plugin.Blosc2.BITSHUFFLE,
-)
 
 
 def md5sum(data: bytes, *args) -> str:
@@ -373,19 +365,6 @@ def _bytes_to_str(data: bytes) -> str:
     """converts bytes into string"""
     return data.decode("utf8")
 
-
-@define_app
-def blosc_compress_it(data: bytes) -> bytes:
-    return blosc2.compress(data, clevel=9, filter=blosc2.Filter.SHUFFLE)
-
-
-@define_app
-def blosc_decompress_it(data: bytes, as_bytearray: bool = True) -> bytes:
-    return bytes(blosc2.decompress(data, as_bytearray=as_bytearray))
-
-
-eti_compress_it = _str_to_bytes() + blosc_compress_it()
-eti_decompress_it = blosc_decompress_it() + _bytes_to_str()
 
 _biotypes = re.compile(r"(gene|transcript|exon|mRNA|rRNA|protein):")
 

--- a/src/ensembl_tui/data/sample.cfg
+++ b/src/ensembl_tui/data/sample.cfg
@@ -6,11 +6,11 @@ host=ftp.ensembl.org
 # and where the installation will be placed.
 # The paths can be absolute (begin with /), as in this case,
 # or relative to the location of this cfg file (begin with ./).
-staging_path=ensembl_download_114
-install_path=ensembl_install_114
+staging_path=ensembl_download
+install_path=ensembl_install
 [release]
 # The release of Ensembl that you want to sample data from.
-release=114
+release=115
 [Saccharomyces cerevisiae]
 # You specify the species that you want to be downloaded by including the 
 # Latin or common name (as defined by Ensembl) within the square brackets.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,7 +212,7 @@ def apes_install(data_url, data_dir, data_name):
 
 @pytest.fixture(scope="session")
 def apes_install_path(DATA_DIR):
-    return apes_install(TEST_DATA_URL, DATA_DIR, APES_DATA_DIRNAME)
+    return apes_install(TEST_APES_DATA_URL, DATA_DIR, APES_DATA_DIRNAME)
 
 
 TEST_APES_MAF_URL = "https://www.dropbox.com/scl/fi/9kc57hitzhwwifq35je8l/apes-114-maf.zip?rlkey=mxeytmuv672cpfar7iirh7emm&dl=1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _species as eti_species
 from ensembl_tui import _util as eti_util
 
+_ensembl_release = "115"
+
 
 @pytest.fixture(scope="session")
 def DATA_DIR():
@@ -23,7 +25,7 @@ def default_species_map():
 
 @pytest.fixture(scope="session")
 def ENSEMBL_RELEASE_VERSION() -> str:
-    return "114"
+    return _ensembl_release
 
 
 @pytest.fixture
@@ -58,7 +60,7 @@ def namer():
 
 
 TEST_DATA_URL = "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
-SMALL_DATA_DIRNAME = "small-114"
+SMALL_DATA_DIRNAME = f"small-{_ensembl_release}"
 
 
 @pytest.fixture(scope="session")
@@ -192,7 +194,7 @@ def tmp_config_no_compara(tmp_path_factory, small_download_path):
 
 
 TEST_APES_DATA_URL = "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
-APES_DATA_DIRNAME = "apes-114"
+APES_DATA_DIRNAME = f"apes-{_ensembl_release}"
 
 
 def apes_install(data_url, data_dir, data_name):
@@ -214,7 +216,7 @@ def apes_install_path(DATA_DIR):
 
 
 TEST_APES_MAF_URL = "https://www.dropbox.com/scl/fi/9kc57hitzhwwifq35je8l/apes-114-maf.zip?rlkey=mxeytmuv672cpfar7iirh7emm&dl=1"
-APES_MAF_DIRNAME = "apes-114-maf"
+APES_MAF_DIRNAME = f"apes-{_ensembl_release}-maf"
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def namer():
     return name_as_seqid
 
 
-TEST_DATA_URL = "https://www.dropbox.com/scl/fi/a3dkt04z7d1t2p3io1pp6/small-114.zip?rlkey=di9ty6diu1kusjsopam891zyg&dl=1"
+TEST_DATA_URL = "https://www.dropbox.com/scl/fi/cknsuhd6k8t6fjn1odzog/small-115.zip?rlkey=zkacmbhx4ssf4v80d78dd9uql&dl=1"
 SMALL_DATA_DIRNAME = f"small-{_ensembl_release}"
 
 
@@ -193,7 +193,7 @@ def tmp_config_no_compara(tmp_path_factory, small_download_path):
     return dest
 
 
-TEST_APES_DATA_URL = "https://www.dropbox.com/scl/fi/cyr1p5aqteffsggtlqjo7/apes-114.zip?rlkey=sbq1h0kx37fz7gsmlblherxr5&dl=1"
+TEST_APES_DATA_URL = "https://www.dropbox.com/scl/fi/h6kd0rlntvyzcb6d485fa/apes-115.zip?rlkey=4hza000j7btue6qwnxvnid5gb&dl=1"
 APES_DATA_DIRNAME = f"apes-{_ensembl_release}"
 
 
@@ -215,7 +215,7 @@ def apes_install_path(DATA_DIR):
     return apes_install(TEST_APES_DATA_URL, DATA_DIR, APES_DATA_DIRNAME)
 
 
-TEST_APES_MAF_URL = "https://www.dropbox.com/scl/fi/9kc57hitzhwwifq35je8l/apes-114-maf.zip?rlkey=mxeytmuv672cpfar7iirh7emm&dl=1"
+TEST_APES_MAF_URL = "https://www.dropbox.com/scl/fi/2wmle5kzjdqralppvddsr/apes-115-maf.zip?rlkey=u1hbfo0jqwhfkfukntgx5tbfn&dl=1"
 APES_MAF_DIRNAME = f"apes-{_ensembl_release}-maf"
 
 

--- a/tests/data/prep_tests_data/apes.cfg
+++ b/tests/data/prep_tests_data/apes.cfg
@@ -2,10 +2,10 @@
 path = pub
 host = ftp.ensembl.org
 [local path]
-staging_path = apes-114-download
-install_path = apes-114
+staging_path = apes-115-download
+install_path = apes-115
 [release]
-release = 114
+release = 115
 [compara]
 align_names = 10_primates.epo
 homologies =
@@ -15,3 +15,8 @@ db = core
 db = core
 [gorilla_gorilla]
 db = core
+[species_map]
+header = genome_name	abbrev	common_name	db_prefix
+homo_sapiens=human	Human	homo_sapiens
+gorilla_gorilla=gorilla	Gorilla	gorilla_gorilla
+pan_troglodytes=chimp	Chimpanzee	pan_troglodytes

--- a/tests/data/prep_tests_data/prep_ape_test.py
+++ b/tests/data/prep_tests_data/prep_ape_test.py
@@ -102,10 +102,15 @@ _click_command_opts = {
 @click.argument("install_dir", type=pathlib.Path)
 @click.argument("download_dir", type=pathlib.Path)
 @click.option("--check", is_flag=True)
-def main(install_dir, download_dir, check):
+@click.option("--release", required=True, type=str)
+def main(install_dir, download_dir, check, release):
     seqid = "22"
     # copy smallest maf file for chrom 22
-    copy_maf(download_dir / "downloaded.cfg", pathlib.Path("apes-114-maf"), seqid=seqid)
+    copy_maf(
+        download_dir / "downloaded.cfg",
+        pathlib.Path(f"apes-{release}-maf"),
+        seqid=seqid,
+    )
     cfg = eti_config.read_installed_cfg(install_dir)
 
     for db in cfg.list_genomes():

--- a/tests/data/small.cfg
+++ b/tests/data/small.cfg
@@ -1,11 +1,10 @@
 [remote path]
 host=ftp.ensembl.org
-path=pub
 [local path]
-staging_path=small-114/download
-install_path=small-114/install
+staging_path=small-115/download
+install_path=small-115/install
 [release]
-release=114
+release=115
 [Saccharomyces cerevisiae]
 db=core
 [Caenorhabditis elegans]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,11 +8,11 @@ from ensembl_tui import _site_map as eti_smap
 
 @pytest.mark.internet
 @pytest.mark.timeout(10)
-def test_get_db_names(tmp_config):
+def test_get_db_names(tmp_config, ENSEMBL_RELEASE_VERSION):
     cfg = eti_config.read_config(config_path=tmp_config)
     db_names = eti_download.get_core_db_dirnames(cfg)
     assert db_names == {
-        "saccharomyces_cerevisiae": "pub/release-114/mysql/saccharomyces_cerevisiae_core_114_4",
+        "saccharomyces_cerevisiae": f"pub/release-{ENSEMBL_RELEASE_VERSION}/mysql/saccharomyces_cerevisiae_core_{ENSEMBL_RELEASE_VERSION}_4",
     }
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -171,14 +171,6 @@ def test_cfg_to_dict(just_compara_cfg):
     assert got_cfg.to_dict() == data
 
 
-def test_blosc_apps():
-    o = "ACGG" * 1000
-    z = eti_util.eti_compress_it(o)
-    assert isinstance(z, bytes)
-    assert len(z) < len(o)
-    assert eti_util.eti_decompress_it(z) == o
-
-
 def test_get_sig_calc_func_invalid():
     with pytest.raises(NotImplementedError):
         eti_util.get_sig_calc_func(2)


### PR DESCRIPTION
## Summary by Sourcery

Update project to Ensembl release 115, refresh CI and test data workflows, parameterize release version, drop Blosc support, and bump key dependencies

New Features:
- Allow prep_ape_test script to accept a dynamic --release option for configurable data paths.

Enhancements:
- Upgrade Ensembl release references from 114 to 115 across sample configs, test fixtures, and scripts.
- Simplify sample configuration paths by removing hard-coded version suffixes.
- Replace static file names and paths in tests with a dynamic ENSEMBL_RELEASE_VERSION fixture.
- Remove HDF5/Blosc compression utilities and eliminate the blosc2 dependency.
- Refine the close method docstring in the alignment module to match storage changes.

Build:
- Bump cogent3 to 2025.9.8a3 and cogent3-h5seqs to 0.7.0 in pyproject.toml.

CI:
- Update CI cache keys and download steps for small, apes, and apes-maf test data to use version 115.

Tests:
- Remove obsolete blosc compression tests.
- Update test_get_db_names to utilize ENSEMBL_RELEASE_VERSION fixture for path assertions.