### PR TITLE
MAINT: add ensembl release info to output from installed command

### DIFF
--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -437,7 +437,7 @@ class _printer:  # noqa: N801
 
     def __call__(self, text: str, colour: str, style: str = "") -> None:
         """print text in colour"""
-        msg = rich_text.Text(text, style=style)
+        msg = rich_text.Text.from_markup(text, style=style)
         msg.stylize(colour)
         self._console.print(msg)
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -235,7 +235,9 @@ def installed(installed: pathlib.Path) -> None:
     from cogent3 import make_table
 
     config = eti_config.read_installed_cfg(installed)
-
+    eti_util.print_colour(
+        f"[bold]Ensembl release:[/bold] {config.release}", colour="blue"
+    )
     genome_dir = config.genomes_path
     if genome_dir.exists():
         species = [fn.name for fn in genome_dir.glob("*")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,7 @@ def test_installed(installed):
     assert sum(f.stat().st_size for f in config.homologies_path.iterdir()) > 8_000
     r = RUNNER.invoke(eti_cli.installed, [f"-i{installed}"], catch_exceptions=False)
     assert r.exit_code == 0, r.output
+    assert "Ensembl release:" in r.output
     assert "Installed genomes" in r.output
     assert "caenorhabditis_elegans" in r.output
     path = config.installed_genome("caenorhabditis_elegans")


### PR DESCRIPTION
## Summary by Sourcery

Add display of Ensembl release information to the installed CLI command by printing the release from the configuration in styled output, update the printing utility to support markup, and include a test to ensure the release info appears.

New Features:
- Display Ensembl release number in the output of the installed command

Enhancements:
- Use Text.from_markup in the print utility to support markup styling

Tests:
- Add test assertion to verify that the Ensembl release information is shown in the installed command output