### PR TITLE
DOC: update docs to revised cli for species map info

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -10,16 +10,19 @@
 $ eti demo-config --outpath demo
 ```
 
-The config template file is written to the specified directory along with a `species.tsv` file which includes a listing of Ensembl species.
+The config template file is written to the specified directory along with a `species.tsv` file which includes a listing of Ensembl species from main site the latest species listing from Ensembl is downloaded and written to `species-full.tsv`. 
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ ls demo/
 ```
 
+!!! note
+    use help to see the currently supported Ensembl domains to download species data from using under `eti demo-config --help`
+
 ### The species contents
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
-$ head -n 5 demo/species.tsv
+$ head -n 5 demo/species-full.tsv
 ```
 
 ### The config contents
@@ -46,7 +49,7 @@ Specify the ensemble release.
 
 ### `[<species name>]`
 
-Selecting a species is done by providing a section with the species name as a section. Available species can be found in the species.tsv file which is written out by the `demo-config` command.
+Selecting a species is done by providing a section with the species name as a section. You can provide an abbreviation of the species name, which can be found in the `species-full.tsv` file which is written out by the `demo-config` command.
 
 For now, you must include `db=core` under the species section.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,9 +11,24 @@ $ eti install -d <dirname>
 !!! note
     You can utilize multiple processes on your machine for this installation step with the `-np #` argument. We recommend specifying the same number of processes as the number of genomes, e.g. `-np 10` for ten genomes.
 
+## What Is Installed
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ ls data/apes-115
+```
+
+The `installed.cfg` file also specifies the Ensembl release, the software versions used during installation, and under the section `species_map`, the mapping of genome names to different "names", such as the abbreviation. This is just a plain text file which you can edit.
+
+!!! note
+    Changing the abbreviations to something that you find easier to type can be useful as these are employed in the command line interface.
+
+```console exec="1" source="console" result="ansi" workdir="./docs"
+$ cat data/apes-115/installed.cfg
+```
+
 ## Check Your Installation
 
-Once you have finished your installation, you can check its contents using the `installed` command.
+Once you have finished your installation, you can check its contents using the `installed` command. This includes the listing of software versions at the time of the installation (useful for troubleshooting) plus species names, abbreviations etc..
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti installed -i data/apes-115
@@ -24,3 +39,5 @@ $ eti installed -i data/apes-115
 
 !!! warning
     At present, installation is not interruptible. If you need to reinstall, you will need to force overwriting of the current installation using the `--force_overwrite` argument.
+
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ $ eti demo-config -o demo
 
 ## Download The Specified Data
 
-We use a custom config file which specifies just bakers yeast the the worm. (You can do this yourself by :material-download: [downloading the small.cfg](data/small.cfg) and executing the following command
+We use a custom config file which specifies just "yeast" and "worm". (You can do this yourself by :material-download: [downloading the small.cfg](data/small.cfg) and executing the following command
 
 ```
 $ eti download -c <path to>/small.cfg
@@ -36,7 +36,7 @@ $ eti download -c <path to>/small.cfg
 The data will be downloaded to `staging_path` specified in `small.cfg`, which is interpreted relative to the directory in which you executed the command.
 
 !!! note
-    Downloads can be interrupted.
+    If a download is interrupted and restarted, `eti` resumes downloads from where it stopped.
 
 ## Make The Local Installation
 


### PR DESCRIPTION
## Summary by Sourcery

Update documentation to reflect revised CLI behavior for species mapping and configuration, including detailing the installed.cfg file, introducing the species-full.tsv file, and clarifying download resumability.

Enhancements:
- Add a "What Is Installed" section in install docs describing the installed.cfg file and species_map abbreviations
- Enhance the install guide to note that the installed command lists software versions, species names, and abbreviations
- Update config docs to document downloading the latest Ensembl species into species-full.tsv and clarify species name abbreviations
- Add a note to use `eti demo-config --help` to view supported Ensembl domains for species data
- Correct the quickstart example to specify "yeast" and "worm" and note that downloads resume if interrupted