### PR TITLE
Bug fix etc..

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ license = { file = "LICENSE" }
 requires-python = ">=3.11,<3.14"
 dependencies = [
         "click",
-        "cogent3==2025.9.8a3",
-        "cogent3-h5seqs==0.7.1",
+        "cogent3==2025.9.8a7",
+        "cogent3-h5seqs==0.7.2",
         "duckdb",
         "numba",
         "numpy",

--- a/src/ensembl_tui/_homology.py
+++ b/src/ensembl_tui/_homology.py
@@ -201,14 +201,16 @@ class collect_cds:
 
     def main(self, homologs: homolog_group) -> SeqsCollectionType:
         namer = self._namer
-        seqs = []
+        seqs = {}
         for species, sp_genes in homologs.species_ids().items():
             if species not in self._genomes:
                 self._genomes[species] = eti_genome.load_genome(
                     config=self._config,
                     species=species,
                 )
+
             genome = self._genomes[species]
+
             for name in sp_genes:
                 cds = list(
                     genome.get_features(name=name, biotype="cds", canonical=True),
@@ -223,13 +225,8 @@ class collect_cds:
 
                 feature = cds[0]
                 seq = feature.get_slice()
-                seq.name = f"{species}-{name}" if namer is None else namer(feature)
-                seq.info["species"] = species
-                seq.info["name"] = name
-                # disconnect from annotation so the closure of the genome
-                # does not cause issues when run in parallel
-                seq.annotation_db = None
-                seqs.append(seq)
+                name = f"{species}-{name}" if namer is None else namer(feature)
+                seqs[name] = str(seq)
 
         if not seqs:
             return NotCompleted(

--- a/tests/test_homology.py
+++ b/tests/test_homology.py
@@ -1,6 +1,8 @@
 import pytest
-from cogent3 import load_table
+from cogent3 import get_moltype, load_table
 
+from ensembl_tui import _config as eti_config
+from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _homology as eti_homology
 from ensembl_tui import _ingest_homology as homol_ingest
 
@@ -314,3 +316,26 @@ def test_extract_homology_data(hom_dir):
     for result in loader.as_completed(hom_dir.glob("*.tsv.gz"), show_progress=False):
         records.extend(result.obj)
     assert len(records) == 2
+
+
+@pytest.mark.parametrize(
+    ["hsap_gid", "strand"], [("ENSG00000128274", -1), ("ENSG00000130487", 1)]
+)
+def test_get_homologs_one_exon(apes_install_path, hsap_gid, strand):
+    config = eti_config.read_installed_cfg(apes_install_path)
+    get_seqs = eti_homology.collect_cds(config=config)
+    genomes = {
+        sp: str(eti_genome.load_genome(config=config, species=sp).seqs["22"])
+        for sp in config.list_genomes()
+    }
+    homdb = eti_homology.load_homology_db(
+        path=config.homologies_path,
+    )
+    related = homdb.get_related_to(
+        gene_id=hsap_gid, relationship_type="ortholog_one2one"
+    )
+    result = get_seqs.main(related).rename_seqs(lambda x: x.split("-")[0]).to_dict()
+    transform = (lambda x: x) if strand == 1 else get_moltype("dna").rc
+    # as they're single exon genes, they should all be in their
+    # genome chromosome
+    assert all(transform(s) in genomes[n] for n, s in result.items())


### PR DESCRIPTION
## Summary by Sourcery

Improve CDS homology retrieval by returning raw sequence strings keyed by name, update related tests to cover single-exon orthologs, and bump cogent3 dependencies.

Enhancements:
- Update collect_cds.main to accumulate sequences in a name-to-string dictionary and drop Seq object metadata

Build:
- Bump cogent3 and cogent3-h5seqs dependencies to newer patch versions

Tests:
- Add parameterized test for retrieving CDS sequences of single-exon orthologs and verifying orientation and chromosome assignment