### PR TITLE
Improve test performance

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: "Run nox for ${{ matrix.python-version }}"
         run: |
-          nox -db uv -s test-${{ matrix.python-version }} -- -m 'internet' --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}-internet.lcov --cov-report term --cov-append --cov ensembl_tui
+          nox -db uv -s test-${{ matrix.python-version }} -- -m 'internet' --durations=10 --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}-internet.lcov --cov-report term --cov-append --cov ensembl_tui
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: "Run nox for ${{ matrix.python-version }}"
         run: |
-          nox -db uv --force-python python -s test -- -m 'not internet' --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov ensembl_tui
+          nox -db uv --force-python python -s test -- -m 'not internet' --durations=10 --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov ensembl_tui
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,13 @@
+import os
+import sys
+
 import nox
 
 _py_versions = range(10, 14)
+
+# on python >= 3.12 this will improve speed of test coverage a lot
+if sys.version_info >= (3, 12):
+    os.environ["COVERAGE_CORE"] = "sysmon"
 
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.11,<3.14"
 dependencies = [
         "click",
-        "cogent3==2025.9.8a7",
+        "cogent3==2025.9.8a8",
         "cogent3-h5seqs==0.7.2",
         "duckdb",
         "numba",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def tmp_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def tmp_config(tmp_dir):
+def tmp_config_just_yeast(tmp_dir):
     # create a simpler download config
     # we want a very small test set
     parser = ConfigParser()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,19 +171,19 @@ def genome_dir(small_install_cfg):
     return small_install_cfg.installed_genome(species="caenorhabditis_elegans")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tmp_config_no_compara(tmp_path_factory, small_download_path):
     # modify the small_download_path to remove the compara folder
     tmp_path = tmp_path_factory.mktemp("downloaded")
     dest = tmp_path / small_download_path.name
     shutil.copytree(small_download_path, dest)
-    shutil.rmtree(dest / "genomes" / "saccharomyces_cerevisiae")
+    shutil.rmtree(dest / "genomes" / "caenorhabditis_elegans")
     shutil.rmtree(dest / "compara")
 
     # create a config with one specie but without compara section
     parser = ConfigParser()
     parser.read(next(iter(small_download_path.glob("*cfg"))))
-    parser.remove_section("saccharomyces_cerevisiae")
+    parser.remove_section("caenorhabditis_elegans")
     parser.remove_section("compara")
 
     download_cfg = dest / "downloaded.cfg"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,12 +15,14 @@ RUNNER = CliRunner()
 @pytest.mark.slow
 @pytest.mark.internet
 @pytest.mark.timeout(120)
-def test_download(tmp_config):
+def test_download(tmp_config_just_yeast):
     """runs download, install, drop according to a special test cfg"""
-    tmp_dir = tmp_config.parent
+    tmp_dir = tmp_config_just_yeast.parent
     # now download
 
-    r = RUNNER.invoke(eti_cli.download, [f"-c{tmp_config}"], catch_exceptions=False)
+    r = RUNNER.invoke(
+        eti_cli.download, [f"-c{tmp_config_just_yeast}"], catch_exceptions=False
+    )
     assert r.exit_code == 0, r.output
     # make sure the download checkpoint file exists
     genome_dir = tmp_dir / "staging" / "genomes"
@@ -77,12 +79,31 @@ def installed(tmp_downloaded):
     return tmp_downloaded.parent / "install"
 
 
-@pytest.mark.slow
-def test_installed(installed):
-    config = eti_config.read_installed_cfg(installed)
+def test_do_install(tmp_config_no_compara):
+    r = RUNNER.invoke(
+        eti_cli.install,
+        [f"-d{tmp_config_no_compara}", "-v", "-f"],
+        catch_exceptions=False,
+    )
+    assert r.exit_code == 0, r.output
+    install_dir = tmp_config_no_compara.parent / "install"
+    assert install_dir.exists()
+    config = eti_config.read_installed_cfg(install_dir)
+    assert not config.homologies_path.exists()
+    r = RUNNER.invoke(eti_cli.installed, [f"-i{install_dir}"], catch_exceptions=False)
+    assert r.exit_code == 0, r.output
+    assert "Ensembl release:" in r.output
+    assert "Installed genomes" in r.output
+    assert "saccharomyces_cerevisiae" in r.output
+
+
+def test_installed(small_install_path):
+    config = eti_config.read_installed_cfg(small_install_path)
     assert config.homologies_path.exists()
     assert sum(f.stat().st_size for f in config.homologies_path.iterdir()) > 8_000
-    r = RUNNER.invoke(eti_cli.installed, [f"-i{installed}"], catch_exceptions=False)
+    r = RUNNER.invoke(
+        eti_cli.installed, [f"-i{small_install_path}"], catch_exceptions=False
+    )
     assert r.exit_code == 0, r.output
     assert "Ensembl release:" in r.output
     assert "Installed genomes" in r.output
@@ -123,12 +144,11 @@ def test_installed_invalid_path():
     assert r.exit_code != 0, r.output
 
 
-@pytest.mark.slow
-def test_check_one_cds_seq(installed):
+def test_check_one_cds_seq(small_install_path):
     # checking a single exon sequence with a rel_start > 0
     from ensembl_tui import _genome as eti_genome
 
-    config = eti_config.read_installed_cfg(installed)
+    config = eti_config.read_installed_cfg(small_install_path)
     genome = eti_genome.load_genome(
         config=config,
         species="saccharomyces_cerevisiae",
@@ -149,13 +169,12 @@ def test_check_one_cds_seq(installed):
     assert str(seq) == expect
 
 
-@pytest.mark.slow
-def test_check_multi_exon_cds_seq_plus_strand(installed):
+def test_check_multi_exon_cds_seq_plus_strand(small_install_path):
     # checking a multi exon sequence with a rel_start > 0
     # and rel_end != exon length
     from ensembl_tui import _genome as eti_genome
 
-    config = eti_config.read_installed_cfg(installed)
+    config = eti_config.read_installed_cfg(small_install_path)
     genome = eti_genome.load_genome(
         config=config,
         species="caenorhabditis_elegans",
@@ -170,13 +189,12 @@ def test_check_multi_exon_cds_seq_plus_strand(installed):
     assert len(aa) == 274
 
 
-@pytest.mark.slow
-def test_check_two_exon_cds_seq_rev_strand(installed):
+def test_check_two_exon_cds_seq_rev_strand(small_install_path):
     # checking a two exon sequence with a rel_start > 0
     # and rel_end != exon length
     from ensembl_tui import _genome as eti_genome
 
-    config = eti_config.read_installed_cfg(installed)
+    config = eti_config.read_installed_cfg(small_install_path)
     genome = eti_genome.load_genome(
         config=config,
         species="caenorhabditis_elegans",
@@ -191,11 +209,10 @@ def test_check_two_exon_cds_seq_rev_strand(installed):
     assert len(aa) == 161
 
 
-@pytest.mark.slow
-def test_species_summary(installed):
+def test_species_summary(small_install_path):
     r = RUNNER.invoke(
         eti_cli.species_summary,
-        [f"-i{installed}", "--species", "caenorhabditis_elegans"],
+        [f"-i{small_install_path}", "--species", "caenorhabditis_elegans"],
         catch_exceptions=False,
     )
     assert r.exit_code == 0, r.output
@@ -224,13 +241,12 @@ def test_species_summary_invalid_species(apes_install_path, bad_species):
     assert r.exit_code != 0, r.output
 
 
-@pytest.mark.slow
-def test_dump_genes(installed):
+def test_dump_genes(small_install_path):
     species = "caenorhabditis_elegans"
-    outdir = installed.parent
+    outdir = small_install_path.parent
     limit = 10
     args = [
-        f"-i{installed}",
+        f"-i{small_install_path}",
         "--species",
         species,
         "--outdir",
@@ -270,12 +286,11 @@ def test_dump_genes_error(apes_install_path, bad_species):
     assert r.exit_code != 0, r.output
 
 
-@pytest.mark.slow
-def test_homologs(installed, tmp_dir):
+def test_homologs(small_install_path, tmp_dir):
     outdir = tmp_dir / "output"
     limit = 10
     args = [
-        f"-i{installed}",
+        f"-i{small_install_path}",
         "--ref",
         "caenorhabditis_elegans",
         "--outdir",
@@ -344,12 +359,11 @@ def test_homologs_error_refgenes_coords(
     assert r.exit_code != 0, r.output
 
 
-@pytest.mark.slow
-def test_homologs_coord_name(installed, tmp_dir):
+def test_homologs_coord_name(small_install_path, tmp_dir):
     outdir = tmp_dir / "output"
     limit = 10
     args = [
-        f"-i{installed}",
+        f"-i{small_install_path}",
         "--ref",
         "saccharomyces_cerevisiae",
         "--outdir",
@@ -373,11 +387,10 @@ def test_homologs_coord_name(installed, tmp_dir):
     assert len(dstore.completed) == limit
 
 
-@pytest.mark.slow
-def test_compara_summary(installed):
+def test_compara_summary(small_install_path):
     r = RUNNER.invoke(
         eti_cli.compara_summary,
-        [f"-i{installed}"],
+        [f"-i{small_install_path}"],
         catch_exceptions=False,
     )
     assert r.exit_code == 0, r.output
@@ -398,7 +411,6 @@ def test_compara_summary_apes(apes_install_path):
     assert "10_primates" in r.output
 
 
-@pytest.mark.slow
 def test_compara_folder_not_created(tmp_config_no_compara):
     # ensure compara folder is not created if not specified in the config
     r = RUNNER.invoke(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,8 +39,8 @@ def test_installed_homologies(default_species_map):
 
 
 @pytest.fixture
-def installed_cfg_path(tmp_config):
-    config = eti_config.read_config(config_path=tmp_config)
+def installed_cfg_path(tmp_config_just_yeast):
+    config = eti_config.read_config(config_path=tmp_config_just_yeast)
     return eti_config.write_installed_cfg(config)
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,8 +8,8 @@ from ensembl_tui import _site_map as eti_smap
 
 @pytest.mark.internet
 @pytest.mark.timeout(10)
-def test_get_db_names(tmp_config, ENSEMBL_RELEASE_VERSION):
-    cfg = eti_config.read_config(config_path=tmp_config)
+def test_get_db_names(tmp_config_just_yeast, ENSEMBL_RELEASE_VERSION):
+    cfg = eti_config.read_config(config_path=tmp_config_just_yeast)
     db_names = eti_download.get_core_db_dirnames(cfg)
     assert db_names == {
         "saccharomyces_cerevisiae": f"pub/release-{ENSEMBL_RELEASE_VERSION}/mysql/saccharomyces_cerevisiae_core_{ENSEMBL_RELEASE_VERSION}_4",

--- a/tests/test_homology.py
+++ b/tests/test_homology.py
@@ -1,5 +1,5 @@
+import cogent3 as c3
 import pytest
-from cogent3 import get_moltype, load_table
 
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
@@ -37,7 +37,7 @@ def o2o_db(DATA_DIR, tmp_dir):
         "species_2",
         "gene_id_2",
     )
-    table = load_table(raw).get_columns(src_cols)
+    table = c3.load_table(raw).get_columns(src_cols)
     table = table.with_new_header(src_cols, dest_col)
     table = table.get_columns(["relationship", "gene_id_1", "gene_id_2"])
     species = {
@@ -300,7 +300,7 @@ def test_homdb_num_records(o2o_db):
 @pytest.fixture
 def hom_dir(DATA_DIR, tmp_path):
     path = DATA_DIR / "small_protein_homologies.tsv.gz"
-    table = load_table(path)
+    table = c3.load_table(path)
     outpath = tmp_path / "small_1.tsv.gz"
     table[:1].write(outpath)
     outpath = tmp_path / "small_2.tsv.gz"
@@ -319,7 +319,7 @@ def test_extract_homology_data(hom_dir):
 
 
 @pytest.mark.parametrize(
-    ["hsap_gid", "strand"], [("ENSG00000128274", -1), ("ENSG00000130487", 1)]
+    ("hsap_gid", "strand"), [("ENSG00000128274", -1), ("ENSG00000130487", 1)]
 )
 def test_get_homologs_one_exon(apes_install_path, hsap_gid, strand):
     config = eti_config.read_installed_cfg(apes_install_path)
@@ -334,8 +334,8 @@ def test_get_homologs_one_exon(apes_install_path, hsap_gid, strand):
     related = homdb.get_related_to(
         gene_id=hsap_gid, relationship_type="ortholog_one2one"
     )
-    result = get_seqs.main(related).rename_seqs(lambda x: x.split("-")[0]).to_dict()
-    transform = (lambda x: x) if strand == 1 else get_moltype("dna").rc
+    result = get_seqs.main(related).renamed_seqs(lambda x: x.split("-")[0]).to_dict()
+    transform = (lambda x: x) if strand == 1 else c3.get_moltype("dna").rc
     # as they're single exon genes, they should all be in their
     # genome chromosome
     assert all(transform(s) in genomes[n] for n, s in result.items())

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,6 +7,7 @@ import pytest
 import ensembl_tui._config as eti_config
 import ensembl_tui._ingest_annotation as eti_db_ingest
 import ensembl_tui._mysql_core_attr as eti_tables
+from ensembl_tui import _install as eti_install
 from ensembl_tui import _storage_mixin as eti_storage
 
 TRANSLATION_SCHEMA = (
@@ -694,3 +695,14 @@ def test_make_transcript_attr(mixed_data):
     spans = eti_storage.blob_to_array(result)
     expect = numpy.array([[900, 1000], [1100, 1200], [1300, 1400]], dtype=numpy.int32)
     assert numpy.allclose(spans, expect)
+
+
+def test_install_homology(tmp_downloaded):
+    # just install homology data
+    config = eti_config.read_config(config_path=tmp_downloaded / "downloaded.cfg")
+    eti_install.local_install_homology(
+        config=config, force_overwrite=True, max_workers=1
+    )
+    expect = config.install_homologies / "homology_groups_attr.parquet"
+    assert expect.exists()
+    assert expect.stat().st_size > 8_000

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,17 +8,17 @@ from ensembl_tui import _util as eti_util
 
 
 @pytest.fixture(scope="function")
-def compara_cfg(tmp_config):
+def compara_cfg(tmp_config_just_yeast):
     # we just add compara sections
     parser = ConfigParser()
-    parser.read(eti_util.get_resource_path(tmp_config))
+    parser.read(eti_util.get_resource_path(tmp_config_just_yeast))
     parser.add_section("compara")
     alns = ",".join(("17_sauropsids.epc", "10_primates.epo"))
     parser.set("compara", "align_names", value=alns)
-    with open(tmp_config, "w") as out:
+    with open(tmp_config_just_yeast, "w") as out:
         parser.write(out)
 
-    return tmp_config
+    return tmp_config_just_yeast
 
 
 def test_parse_config(compara_cfg):
@@ -39,16 +39,16 @@ def test_load_ensembl_checksum(DATA_DIR):
 
 
 @pytest.fixture(scope="function")
-def gorilla_cfg(tmp_config):
+def gorilla_cfg(tmp_config_just_yeast):
     # we add gorilla genome
     parser = ConfigParser()
-    parser.read(eti_util.get_resource_path(tmp_config))
+    parser.read(eti_util.get_resource_path(tmp_config_just_yeast))
     parser.add_section("Gorilla")
     parser.set("Gorilla", "db", value="core")
-    with open(tmp_config, "w") as out:
+    with open(tmp_config_just_yeast, "w") as out:
         parser.write(out)
 
-    return tmp_config
+    return tmp_config_just_yeast
 
 
 def test_parse_config_gorilla(gorilla_cfg):
@@ -90,18 +90,18 @@ def test_valid_seq(name):
 
 
 @pytest.fixture
-def just_compara_cfg(tmp_config):
+def just_compara_cfg(tmp_config_just_yeast):
     # no genomes!
     parser = ConfigParser()
-    parser.read(tmp_config)
+    parser.read(tmp_config_just_yeast)
     parser.remove_section("Saccharomyces cerevisiae")
     parser.add_section("compara")
     parser.set("compara", "align_names", value="10_primates.epo")
     parser.set("compara", "tree_names", value="10_primates_EPO_default.nh")
-    with open(tmp_config, "w") as out:
+    with open(tmp_config_just_yeast, "w") as out:
         parser.write(out)
 
-    return tmp_config
+    return tmp_config_just_yeast
 
 
 @pytest.mark.internet
@@ -113,15 +113,15 @@ def test_just_compara(just_compara_cfg):
     assert len(cfg.species_dbs) == 10
 
 
-def test_write_read_installed_config(tmp_config):
-    config = eti_config.read_config(config_path=tmp_config)
+def test_write_read_installed_config(tmp_config_just_yeast):
+    config = eti_config.read_config(config_path=tmp_config_just_yeast)
     cfg_path = eti_config.write_installed_cfg(config)
     icfg = eti_config.read_installed_cfg(cfg_path.parent)
     assert icfg.release == config.release
     assert icfg.install_path == config.install_path
 
 
-def test_match_align_tree(tmp_config):
+def test_match_align_tree(tmp_config_just_yeast):
     trees = [
         "pub/release-110/compara/species_trees/16_pig_breeds_EPO-Extended_default.nh",
         "pub/release-110/compara/species_trees/21_murinae_EPO_default.nh",
@@ -142,7 +142,7 @@ def test_match_align_tree(tmp_config):
     assert result == expect
 
 
-def test_missing_match_align_tree(tmp_config):
+def test_missing_match_align_tree(tmp_config_just_yeast):
     trees = [
         "pub/release-110/compara/species_trees/16_pig_breeds_EPO-Extended_default.nh",
         "pub/release-110/compara/species_trees/21_murinae_EPO_default.nh",


### PR DESCRIPTION
## Summary by Sourcery

Improve test suite performance and consistency by refactoring fixtures to use smaller datasets, removing slow markers, updating homology tests for the new cogent3 API, and tuning nox and CI configurations for faster coverage; also add new integration tests for installation and homology and bump the cogent3 dependency.

New Features:
- Add test_do_install integration test for installation CLI.
- Add test_install_homology to cover local homology data installation.

Enhancements:
- Refactor tests to use smaller fixtures and remove slow markers for faster execution.
- Rename fixtures to tmp_config_just_yeast and small_install_path for clarity.
- Update homology tests to use cogent3 c3.load_table and get_moltype API.

Build:
- Bump cogent3 dependency to v2025.9.8a8.

CI:
- Enable coverage-core=sysmon on Python >=3.12 in nox sessions.
- Add duration profiling (--durations=10) to nox test runs in GitHub Actions.

Tests:
- Streamline config- and CLI-related tests to adopt new fixture names and consolidated setups.