### PR TITLE
Make MAF parsing robust to source of file

### DIFF
--- a/src/ensembl_tui/_ingest_align.py
+++ b/src/ensembl_tui/_ingest_align.py
@@ -4,9 +4,11 @@ import typing
 import duckdb
 import numpy
 import rich.progress as rich_progress
-from cogent3 import make_seq
+from cogent3 import get_moltype
 from cogent3.app.composable import LOADER, define_app
 from cogent3.app.typing import IdentifierType
+from cogent3.core.alphabet import convert_alphabet
+from cogent3.core.seq_storage import decompose_gapped_seq_array
 
 from ensembl_tui import _align as eti_align
 from ensembl_tui import _config as eti_config
@@ -15,18 +17,18 @@ from ensembl_tui import _util as eti_util
 from ensembl_tui._maf import parse
 
 _no_gaps = numpy.array([], dtype=numpy.int32)
+_dna = get_moltype("dna")
+_dna_alpha = _dna.most_degen_alphabet()
+_src = "".join(_dna.degen_alphabet).lower().encode("utf-8")
+_transform = convert_alphabet(src=_src, dest=_src.upper())
 
 
 def seq2gaps(record: dict) -> eti_align.AlignRecord:
-    seq = make_seq(record.pop("seq").upper(), moltype="dna")
-    indel_map, _ = seq.parse_out_gaps()
-    if indel_map.num_gaps:
-        record["gap_spans"] = numpy.array(
-            [indel_map.gap_pos, indel_map.get_gap_lengths()],
-            dtype=numpy.int32,
-        ).T
-    else:
-        record["gap_spans"] = _no_gaps
+    s = _transform(record.pop("seq").encode("utf-8"))
+    arr = _dna_alpha.to_indices(s)
+    # DNA alphabet's always have a gap index defined as an integer
+    _, gaps = decompose_gapped_seq_array(arr, typing.cast("int", _dna_alpha.gap_index))
+    record["gap_spans"] = gaps if gaps.size else _no_gaps
     return eti_align.AlignRecord(**record)
 
 

--- a/src/ensembl_tui/_ingest_align.py
+++ b/src/ensembl_tui/_ingest_align.py
@@ -91,9 +91,6 @@ def add_records(
         if progress is not None:
             progress.update(writing, description=msg, advance=1)
 
-    if progress is not None:
-        progress.remove_task(writing)
-
 
 def install_alignment(
     config: eti_config.Config,
@@ -128,10 +125,8 @@ def install_alignment(
         if progress is not None:
             progress.update(reading, description=msg, advance=1)
 
-    if progress is not None:
-        progress.remove_task(reading)
-
     add_records(conn=agg, records=records, progress=progress)
+
     # write the parquet file, returns path to that file
     return eti_db_ingest.export_parquet(
         con=agg,

--- a/src/ensembl_tui/_maf.py
+++ b/src/ensembl_tui/_maf.py
@@ -57,7 +57,7 @@ def _get_seqs(lines: list[str]) -> dict[eti_name.MafName, str]:
 
 def parse(
     path: eti_util.PathType,
-) -> typing.Generator[tuple[int, dict[eti_name.MafName, str]]]:
+) -> typing.Iterator[tuple[int, dict[eti_name.MafName, str]]]:
     with open_(path, mode="rb") as infile:
         data = infile.read()
 

--- a/src/ensembl_tui/_maf.py
+++ b/src/ensembl_tui/_maf.py
@@ -1,7 +1,6 @@
 # parser for MAF, defined at
 # https://genome.ucsc.edu/FAQ/FAQformat.html#format5
 
-import re
 import typing
 
 from cogent3 import open_
@@ -9,14 +8,12 @@ from cogent3 import open_
 from ensembl_tui import _name as eti_name
 from ensembl_tui import _util as eti_util
 
-_id_pattern = re.compile(r"(?<=id[:])\s*\d+")
-
 
 def _get_alignment_block_indices(data: list[str]) -> list[tuple[int, int]]:
     blocks = []
     start = None
     for i, line in enumerate(data):
-        if _id_pattern.search(line):
+        if line.startswith("a"):
             if start is not None:
                 blocks.append((start, i))
             start = i
@@ -26,14 +23,6 @@ def _get_alignment_block_indices(data: list[str]) -> list[tuple[int, int]]:
 
     blocks.append((start, i))
     return blocks
-
-
-def process_id_line(line: str) -> int:
-    if match := _id_pattern.search(line):
-        return int(match.group())
-
-    msg = f"{line=} is not a tree id line"
-    raise ValueError(msg)
 
 
 def process_maf_line(line: str) -> tuple[eti_name.MafName, str]:
@@ -68,11 +57,15 @@ def _get_seqs(lines: list[str]) -> dict[eti_name.MafName, str]:
 
 def parse(
     path: eti_util.PathType,
-) -> typing.Iterable[tuple[int, dict[eti_name.MafName, str]]]:
-    with open_(path) as infile:
-        data = infile.readlines()
+) -> typing.Generator[tuple[int, dict[eti_name.MafName, str]]]:
+    with open_(path, mode="rb") as infile:
+        data = infile.read()
 
-    blocks = _get_alignment_block_indices(data)
-    for block_start, block_end in blocks:
-        block_id = process_id_line(data[block_start])
-        yield block_id, _get_seqs(data[block_start + 1 : block_end])
+    # the block ID's are made unique for each alignment by using
+    # the str(sorted(str(MafNames)))
+    data = data.decode("utf-8").splitlines()
+    for block_start, block_end in _get_alignment_block_indices(data):
+        alignment = _get_seqs(data[block_start + 1 : block_end])
+        names = "".join(sorted(str(n) for n in alignment))
+        block_id = eti_util.hash64(names.encode("utf-8"))
+        yield block_id, alignment

--- a/src/ensembl_tui/_util.py
+++ b/src/ensembl_tui/_util.py
@@ -141,6 +141,14 @@ def load_ensembl_md5sum(path: pathlib.Path) -> dict:
     return result
 
 
+def hash64(data: bytes) -> int:
+    """returns 63-bit hash of numpy array as a signed integer"""
+    h = md5(data, usedforsecurity=False)
+    # Take first 8 bytes and mask to 63 bits (keep it positive)
+    hash_val = int.from_bytes(h.digest()[:8], byteorder="big")
+    return hash_val & 0x7FFFFFFFFFFFFFFF  # Mask to 63 bits
+
+
 class atomic_write:  # noqa: N801
     """performs atomic write operations, cleans up if fails"""
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -560,7 +560,7 @@ def test_load_align_records():
         # to deem it a valid seq
         "seq": "-acCAGGAAG",
     }
-    got = eti_ingest_align.seq2gaps(maf_record)
+    got = eti_ingest_align.seq2gaps(maf_record.copy())
     assert (got.gap_spans == numpy.array([[0, 1]], dtype=numpy.int32)).all()
 
 

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -3,19 +3,24 @@ import pytest
 from ensembl_tui import _config as eti_config
 from ensembl_tui import _genome as eti_genome
 from ensembl_tui import _maf as eti_maf
+from ensembl_tui import _util as eti_util
+
+
+def get_expected_block_ids(alignments):
+    expect = set()
+    for alignment in alignments:
+        concat = "".join(sorted(str(n) for n in alignment))
+        expect.add(eti_util.hash64(concat.encode("utf-8")))
+    return expect
 
 
 def test_read(DATA_DIR):
     path = DATA_DIR / "sample.maf"
     blocks = list(eti_maf.parse(path))
     assert len(blocks) == 4
-    block_ids = {b for b, *_ in blocks}
-    assert block_ids == {20060000040557, 20060000042317, 20060000132559, 20060000102888}
-
-
-def test_process_id_line():
-    got = eti_maf.process_id_line("# id: 20060000042317 \n")
-    assert got == 20060000042317
+    block_ids, alignments = zip(*blocks, strict=False)
+    expect = get_expected_block_ids(alignments)
+    assert set(block_ids) == expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Improve MAF parsing to be agnostic to the source by detecting blocks via 'a' lines, computing deterministic block IDs using a new hash64 utility, and refactor gap parsing to use explicit alphabet conversion.

New Features:
- Compute MAF block IDs by hashing sorted alignment names for robustness across file sources
- Add hash64 utility to generate consistent 63-bit integer hashes

Enhancements:
- Simplify MAF block detection by using 'a' prefix and binary file handling with UTF-8 decoding
- Refactor seq2gaps to use explicit DNA alphabet conversion and decompose_gapped_seq_array for gap spans
- Remove regex-based ID parsing and eliminate the now-unused process_id_line function
- Drop manual progress task removal steps in ingest workflows

Tests:
- Update MAF parsing tests to expect dynamic hash-based IDs and remove obsolete ID line tests
- Adjust sequence gap parsing test to operate on a copy of the input record