### PR TITLE
DOC: updated docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,7 +17,7 @@ $ ls demo/
 ```
 
 !!! note
-    use help to see the currently supported Ensembl domains to download species data from using under `eti demo-config --help`
+    Use `eti demo-config --help` to see the currently supported Ensembl domains to download species data from.
 
 ### The species contents
 
@@ -52,6 +52,20 @@ Specify the ensemble release.
 Selecting a species is done by providing a section with the species name as a section. You can provide an abbreviation of the species name, which can be found in the `species-full.tsv` file which is written out by the `demo-config` command.
 
 For now, you must include `db=core` under the species section.
+
+### `[species_map]`
+
+This section represents the species naming information that is used to map names of a genome name, abbreviation, common name and the Ensembl database prefix. A variant of this will be written out to the `downloaded.cfg` and `installed.cfg` files. You can edit the abbreviation data to more memorable, and easy to type, names.
+
+```ini
+[species_map]
+header = genome_name	abbrev	common_name	db_prefix
+caenorhabditis_elegans = worm	caenorhabditis elegans (nematode, n2)	caenorhabditis_elegans
+saccharomyces_cerevisiae = yeast	saccharomyces cerevisiae	saccharomyces_cerevisiae
+```
+
+!!! note
+    This is an optional section. If missing, a species map file wil need to be provided.
 
 ### `[compara]`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,9 @@ $ eti install -d <dirname>
 !!! note
     You can utilize multiple processes on your machine for this installation step with the `-np #` argument. We recommend specifying the same number of processes as the number of genomes, e.g. `-np 10` for ten genomes.
 
+!!! warning
+    At present, installation is not interruptible. If you restart an installation, you will need to force overwriting of the current one using the `--force_overwrite` argument.
+
 ## What Is Installed
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
@@ -26,6 +29,8 @@ The `installed.cfg` file also specifies the Ensembl release, the software versio
 $ cat data/apes-115/installed.cfg
 ```
 
+The output also lists the versions of the software dependencies that were present at the time of installation. This is intended for debugging purposes.
+
 ## Check Your Installation
 
 Once you have finished your installation, you can check its contents using the `installed` command. This includes the listing of software versions at the time of the installation (useful for troubleshooting) plus species names, abbreviations etc..
@@ -36,8 +41,3 @@ $ eti installed -i data/apes-115
 
 !!! note
     Here we start specifying the installation directory using the `-i` option. This is required for all commands that reference an installation.
-
-!!! warning
-    At present, installation is not interruptible. If you need to reinstall, you will need to force overwriting of the current installation using the `--force_overwrite` argument.
-
-

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,8 +53,11 @@ $ eti installed -i data/small-install
 ### Summary Of A Species
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
-$ eti species-summary -i data/small-install --species saccharomyces_cerevisiae
+$ eti species-summary -i data/small-install --species sac-cere
 ```
+
+!!! note
+    We can use the `abbrev` listed above to identify the species.
 
 ### Summary Of Compara
 
@@ -67,7 +70,7 @@ This shows the relationships between the species installed.
 ## Export Gene meta-data
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
-$ eti dump-genes -i data/small-install --species saccharomyces_cerevisiae --outdir yeast
+$ eti dump-genes -i data/small-install --species sac-cere --outdir yeast
 ```
 
 Show the first five lines of the output file.
@@ -79,7 +82,7 @@ $ head -n 5 yeast/saccharomyces_cerevisiae*.tsv
 ## Export Homology Data
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
-$ eti homologs -i data/small-install --ref caenorhabditis_elegans --outdir worm_yeast --homology_type ortholog_one2one --limit 5
+$ eti homologs -i data/small-install --ref cae-eleg --outdir worm_yeast --homology_type ortholog_one2one --limit 5
 ```
 
 Listing the files that are written into the specified `worm_yeast` directory.

--- a/docs/sample-homologs.md
+++ b/docs/sample-homologs.md
@@ -1,6 +1,6 @@
 # Selecting Homologs
 
-Homologs are related genes and the output is the raw sequence which is unaligned.
+Homologs are related genes and the output are the raw (unaligned) sequences.
 
 ```console exec="1" source="console" result="ansi" workdir="./docs"
 $ eti homologs -i data/apes-115 --outdir apes_homologs --ref human --coord_names 22 --limit 5


### PR DESCRIPTION
## Summary by Sourcery

Update documentation to introduce species mapping, clarify commands, and add installation notes

Documentation:
- Add optional [species_map] section to config docs with example and note
- Clarify help command syntax in config docs
- Add warning about non-interruptible installation and note software versions in install docs
- Update quickstart examples to use and explain species abbreviations
- Fix grammar in sample-homologs documentation