### PR TITLE
ENH: add support for processing genomes in collections

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ import sys
 
 import nox
 
-_py_versions = range(10, 14)
+_py_versions = range(10, 15)
 
 # on python >= 3.12 this will improve speed of test coverage a lot
 if sys.version_info >= (3, 12):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,47 +5,48 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "ensembl_tui"
 authors = [
-    { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au"},
-    { name = "Arne Becker", email = "arne@ebi.ac.uk"},
-    { name = "Stefano Giorgetti", email = "sgiorgetti@ebi.ac.uk"},
+    { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au" },
+    { name = "Arne Becker", email = "arne@ebi.ac.uk" },
+    { name = "Stefano Giorgetti", email = "sgiorgetti@ebi.ac.uk" },
 ]
 maintainers = [
-    { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au"},
-    { name = "Arne Becker", email = "arne@ebi.ac.uk"},
-    { name = "Stefano Giorgetti", email = "sgiorgetti@ebi.ac.uk"},
+    { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au" },
+    { name = "Arne Becker", email = "arne@ebi.ac.uk" },
+    { name = "Stefano Giorgetti", email = "sgiorgetti@ebi.ac.uk" },
 ]
 keywords = ["biology", "genomics", "evolution", "bioinformatics"]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 dependencies = [
-        "click",
-        "cogent3==2025.9.8a9",
-        "cogent3-h5seqs==0.7.2",
-        "duckdb",
-        "numba",
-        "numpy",
-        "polars",
-        "pyarrow",
-        "rich",
-        "scitrack",
-        "typing_extensions",
-        "trogon",
-        "unsync",
-        # restricting wakepy to macOS for now
-        "wakepy>0.7; os_name == 'darwin'",
-        ]
+    "click",
+    "cogent3==2026.1.12a1",
+    "cogent3-h5seqs==0.7.3",
+    "duckdb",
+    "numba",
+    "numpy",
+    "polars",
+    "pyarrow",
+    "rich",
+    "scitrack",
+    "typing_extensions",
+    "trogon",
+    "unsync",
+    # restricting wakepy to macOS for now
+    "wakepy>0.7; os_name == 'darwin'",
+]
 classifiers = [
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-    ]
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 dynamic = ["version", "description"]
 
 [project.urls]
@@ -62,9 +63,10 @@ test = [
     "pytest-cov",
     "pytest-timeout",
     "pytest-xdist",
-    "ruff==0.12.10",
-    "nox"]
-doc  = [
+    "ruff==0.14.11",
+    "nox",
+]
+doc = [
     "mkdocs>=1.6.1",
     "markdown-exec[ansi]>=1.10.0",
     "mkdocs-jupyter>=0.25.1",
@@ -73,14 +75,15 @@ doc  = [
     "mdformat-mkdocs",
     "mdformat-black",
 ]
-dev = ["cogapp",
-       "flit",
-       "numpydoc",
-       "psutil",
-       "scriv",
-       "ensembl_tui[doc]",
-       "ensembl_tui[test]",
-       ]
+dev = [
+    "cogapp",
+    "flit",
+    "numpydoc",
+    "psutil",
+    "scriv",
+    "ensembl_tui[doc]",
+    "ensembl_tui[test]",
+]
 
 [tool.flit.sdist]
 include = ["src/*", "tests/*", "pyproject.toml"]
@@ -88,20 +91,27 @@ include = ["src/*", "tests/*", "pyproject.toml"]
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "internet: marks tests that require internet access  (deselect with '-m \"not internet\"')"
-    ]
+    "internet: marks tests that require internet access  (deselect with '-m \"not internet\"')",
+]
 norecursedirs = ["doc", ".nox", "working"]
 addopts = ["--strict-config"]
 testpaths = "tests"
 
 [tool.scriv]
-format="md"
-categories=["Contributors", "ENH", "BUG", "DOC", "Deprecations", "Discontinued"]
-output_file="changelog.md"
-version="literal: src/ensembl_tui/__init__.py:__version__"
-skip_fragments="README.*"
-new_fragment_template="file: changelog.d/templates/new.md.j2"
-entry_title_template="file: changelog.d/templates/title.md.j2"
+format = "md"
+categories = [
+    "Contributors",
+    "ENH",
+    "BUG",
+    "DOC",
+    "Deprecations",
+    "Discontinued",
+]
+output_file = "changelog.md"
+version = "literal: src/ensembl_tui/__init__.py:__version__"
+skip_fragments = "README.*"
+new_fragment_template = "file: changelog.d/templates/new.md.j2"
+entry_title_template = "file: changelog.d/templates/title.md.j2"
 
 [tool.uv]
 reinstall-package = ["cogent3"]

--- a/src/ensembl_tui/_annotation.py
+++ b/src/ensembl_tui/_annotation.py
@@ -10,6 +10,7 @@ import numpy
 from cogent3.core.annotation_db import (
     AnnotationDbABC,
     FeatureDataType,
+    SqliteAnnotationDbMixin,
 )
 
 import ensembl_tui._mysql_core_attr as core_tables
@@ -913,6 +914,14 @@ class Annotations(AnnotationDbABC, eti_storage.ViewMixin):
                 limit=limit,
             )
 
+    def get_records_matching(self, *, seqid: str, **kwargs):
+        yield from self.get_features_matching(seqid=seqid, **kwargs)
+
+    def compatible(
+        self, other_db: SqliteAnnotationDbMixin, symmetric: bool = True
+    ) -> bool:
+        return super().compatible(other_db, symmetric)
+
 
 @dataclasses.dataclass(frozen=True)
 class species_seqid:
@@ -961,3 +970,19 @@ class MultispeciesAnnotations(AnnotationDbABC):
         sp_sid = self.name_map[seqid]
         db = self.species_annotations[sp_sid.species]
         return db.num_matches(seqid=sp_sid.seqid, **kwargs)
+
+    def get_records_matching(self, *, seqid: str, **kwargs):
+        if seqid not in self.name_map:
+            return ()
+        sp_sid = self.name_map[seqid]
+        db = self.species_annotations[sp_sid.species]
+        return db.get_features_matching(seqid=sp_sid.seqid, **kwargs)
+
+    def compatible(
+        self, other_db: SqliteAnnotationDbMixin, symmetric: bool = True
+    ) -> bool:
+        return super().compatible(other_db, symmetric)
+
+    def close(self) -> None:
+        for db in self.species_annotations.values():
+            db.close()

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -43,7 +43,7 @@ def make_relative_to(
 
 @dataclass
 class Config:
-    host: str
+    domain: str  # User-specified domain (e.g., "main", "metazoa")
     release: str
     staging_path: pathlib.Path
     install_path: pathlib.Path
@@ -108,7 +108,7 @@ class Config:
             install_path = str(make_relative_to(self.staging_path, self.install_path))
 
         data = {
-            "remote path": {"host": str(self.host)},
+            "remote path": {"domain": str(self.domain)},
             "local path": {
                 "staging_path": staging_path,
                 "install_path": install_path,
@@ -343,6 +343,79 @@ def _pop_section(
     return data
 
 
+def _validate_and_resolve_domain(remote_section: dict[str, str]) -> tuple[str, str]:
+    """Validate and resolve domain/host from remote path section.
+
+    Handles backward compatibility by accepting both 'domain' and 'host'.
+    If both present, 'domain' takes precedence with a deprecation warning.
+    If only 'host' present, issues deprecation warning.
+
+    Parameters
+    ----------
+    remote_section : dict
+        The [remote path] section from config file
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple of (domain, host) where:
+        - domain: The user-specified domain name (e.g., "main", "metazoa")
+        - host: The resolved FTP hostname from site map (e.g., "ftp.ensembl.org")
+
+    Raises
+    ------
+    SystemExit
+        If validation fails (no domain/host specified, or invalid domain)
+    """
+    import warnings
+
+    domain_value = remote_section.get("domain")
+    host_value = remote_section.get("host")
+
+    # Validation: at least one must be present
+    if not domain_value and not host_value:
+        msg = (
+            "Config error: [remote path] section must contain either 'domain' or 'host'"
+        )
+        raise ValueError(msg)
+
+    # Precedence: domain takes priority if both present
+    if host_value or (domain_value and host_value):
+        if host_value:
+            msg = "The 'host' option in [remote path] is deprecated. Please use 'domain' instead. "
+            "Support for 'host' will be removed in a future version."
+        else:
+            msg = "Both 'domain' and 'host' found in [remote path]. Using 'domain' value. "
+            "The 'host' option is deprecated and will be removed in a future version."
+        warnings.warn(
+            msg,
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        domain = domain_value or host_value
+    elif domain_value:
+        domain = domain_value
+    else:
+        # This case should not occur due to earlier validation
+        eti_util.print_colour(
+            "Config error: Unable to determine domain from [remote path] section",
+            colour="red",
+        )
+        sys.exit(1)
+
+    # Validate domain exists in site map registry
+    available = eti_site_map.get_site_map_names()
+    if domain not in available:
+        msg = f"Invalid domain '{domain}'. Available domains: {', '.join(sorted(available))}"
+        raise ValueError(msg)
+
+    # Resolve the actual FTP host from the site map
+    site_map = eti_site_map.get_site_map(domain)
+    host = site_map.site
+
+    return domain, host
+
+
 def read_config(
     *,
     config_path: pathlib.Path,
@@ -375,8 +448,9 @@ def read_config(
         root_dir = config_path.parent
 
     release = _pop_section(parser, "release")["release"]
-    host = _pop_section(parser, "remote path")["host"]
-    site_map = eti_site_map.get_site_map(host)
+    remote_section = _pop_section(parser, "remote path")
+    domain, host = _validate_and_resolve_domain(remote_section)
+    site_map = eti_site_map.get_site_map(domain)
     # paths
     paths = _pop_section(parser, "local path")
     staging_path = _standardise_path(paths["staging_path"], root_dir)
@@ -443,7 +517,7 @@ def read_config(
         species_dbs |= {n: ["core"] for n in found}
 
     return Config(
-        host=host,
+        domain=domain,
         release=release,
         staging_path=staging_path,
         install_path=install_path,

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -57,6 +57,10 @@ class Config:
         self.staging_path = pathlib.Path(self.staging_path)
         self.install_path = pathlib.Path(self.install_path)
 
+    def get_core_db_names(self) -> list[str]:
+        names = [self.species_map.get_ensembl_db_prefix(n) for n in self.db_names]
+        return [n for n in names if n]
+
     @property
     def staging_template_path(self) -> pathlib.Path:
         return self.staging_genomes / "coredb_templates"
@@ -398,8 +402,7 @@ def read_config(
     for section in parser.sections():
         sec = _pop_section(parser, section)
         dbs = [db.strip() for db in sec["db"].split(",")]
-        # handle synonyms
-        species_name = sp_map.get_ensembl_db_prefix(section, level="raise")
+        species_name = sp_map.get_genome_name(section, level="raise")
         species_dbs[species_name] = dbs
 
     # we also want homologies if we want alignments

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -96,7 +96,7 @@ class Config:
 
     def to_dict(self, relative_paths: bool = True) -> dict[str, dict[str, str]]:
         """returns cfg as a dict"""
-        if not self.db_names:
+        if not self.species_dbs:
             msg = "no db names"
             raise ValueError(msg)
 
@@ -128,7 +128,7 @@ class Config:
         if not data["compara"]:
             data.pop("compara")
 
-        for db_name in self.db_names:
+        for db_name in self.species_dbs:
             data[db_name] = {"db": "core"}
 
         return data

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -299,6 +299,7 @@ def download_homology(
     if not config.homologies:
         return
 
+    # change homologies path to take an argument, which modifies order of path/genome
     remote_template = f"{site_map.remote_path}/release-{config.release}/{site_map.homologies_path}/{{}}"
 
     local = config.staging_homologies

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -153,10 +153,17 @@ def download_species(
 
     for key in config.species_dbs:
         db_prefix = config.species_map.get_ensembl_db_prefix(key)
-        local_root = config.staging_genomes / db_prefix
+        if "collection" in db_prefix:
+            collection_name = db_prefix
+            local_root = config.staging_genomes / key
+        else:
+            collection_name = None
+            local_root = config.staging_genomes / db_prefix
+
         local_root.mkdir(parents=True, exist_ok=True)
+
         # getting genome sequences
-        remote = site_map.get_seqs_path(db_prefix)
+        remote = site_map.get_seqs_path(key, collection_name=collection_name)
         remote_dir = remote_template.format(remote)
         remote_paths = list(
             eti_ftp.listdir(site_map.site, path=remote_dir, pattern=valid_seq_file),
@@ -171,7 +178,7 @@ def download_species(
             remote_paths = [p for p in remote_paths if not eti_util.dont_checksum(p)]
             remote_paths = remote_paths[:4] + paths
 
-        dest_path = config.staging_genomes / db_prefix / "fasta"
+        dest_path = local_root / "fasta"
         dest_path.mkdir(parents=True, exist_ok=True)
         # cleanup previous download attempts
         _remove_tmpdirs(dest_path)
@@ -180,7 +187,7 @@ def download_species(
             host=site_map.site,
             local_dest=dest_path,
             remote_paths=remote_paths,
-            description=f"{db_prefix[:10]}... {icon}",
+            description=f"{key[:10]}... {icon}",
             do_checksum=True,
             progress=progress,
         )
@@ -188,6 +195,8 @@ def download_species(
         # getting the annotations from mysql tables
         remote_dir = sp_db_map[db_prefix]
         remote_paths = get_remote_mysql_paths(remote_dir)
+        # the mysql data will always be under the db_prefix,
+        # even if it's a collection
         dest_path = config.staging_genomes / db_prefix / "mysql"
         dest_path.mkdir(parents=True, exist_ok=True)
         # cleanup previous download attempts

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -37,20 +37,22 @@ def _remove_tmpdirs(path: eti_util.PathType) -> None:
         shutil.rmtree(tmpdir)
 
 
-def get_core_db_dirnames(config: eti_config.Config) -> dict[str, str]:
+def get_core_db_dirnames(
+    config: eti_config.Config, site_map: eti_site_map.SiteMap
+) -> dict[str, str]:
     """maps species name to ftp path to mysql core dbs"""
-    site_map = eti_site_map.get_site_map(config.host)
     remote_release_path = site_map.get_remote_release_path(config.release)
     # get all the mysql db names
     all_db_names = list(
-        eti_ftp.listdir(config.host, f"{remote_release_path}/mysql"),
+        eti_ftp.listdir(site_map.site, f"{remote_release_path}/mysql"),
     )
     selected_species = {}
+    core_db_names = set(config.get_core_db_names())
     for db_name in all_db_names:
         if "_core_" not in db_name:
             continue
         db = eti_name.EnsemblDbName(db_name.rsplit("/", maxsplit=1)[1])
-        if db.prefix in config.species_dbs and db.db_type == "core":
+        if db.db_type == "core" and db.prefix in core_db_names:
             selected_species[db.prefix] = db_name
     return selected_species
 
@@ -132,7 +134,7 @@ def download_species(
             colour="green",
         )
 
-    sp_db_map = get_core_db_dirnames(config)
+    sp_db_map = get_core_db_dirnames(config, site_map=site_map)
 
     # create the duckdb templates for the tables, if they don't exist
     make_core_db_templates(
@@ -157,7 +159,7 @@ def download_species(
         remote = site_map.get_seqs_path(db_prefix)
         remote_dir = remote_template.format(remote)
         remote_paths = list(
-            eti_ftp.listdir(config.host, path=remote_dir, pattern=valid_seq_file),
+            eti_ftp.listdir(site_map.site, path=remote_dir, pattern=valid_seq_file),
         )
         if verbose:
             eti_util.print_colour(text=f"{remote_paths=}", colour="yellow")
@@ -175,7 +177,7 @@ def download_species(
         _remove_tmpdirs(dest_path)
         icon = "🧬🧬"
         eti_ftp.download_data(
-            host=config.host,
+            host=site_map.site,
             local_dest=dest_path,
             remote_paths=remote_paths,
             description=f"{db_prefix[:10]}... {icon}",
@@ -192,7 +194,7 @@ def download_species(
         _remove_tmpdirs(dest_path)
         icon = "📚"
         eti_ftp.download_data(
-            host=config.host,
+            host=site_map.site,
             local_dest=dest_path,
             remote_paths=remote_paths,
             description=f"{db_prefix[:10]}... {icon}",
@@ -238,7 +240,7 @@ def download_aligns(
     valid_compara = valid_compara_align()
     for align_name in config.align_names:
         remote_path = remote_template.format(align_name)
-        remote_paths = list(eti_ftp.listdir(config.host, remote_path, valid_compara))
+        remote_paths = list(eti_ftp.listdir(site_map.site, remote_path, valid_compara))
         if verbose:
             print(remote_paths)
 
@@ -252,7 +254,7 @@ def download_aligns(
         local_dir.mkdir(parents=True, exist_ok=True)
         _remove_tmpdirs(local_dir)
         eti_ftp.download_data(
-            host=config.host,
+            host=site_map.site,
             local_dest=local_dir,
             remote_paths=remote_paths,
             description=f"{align_name[:10]}...",
@@ -302,7 +304,7 @@ def download_homology(
     for db_name in config.db_names:
         remote_path = remote_template.format(db_name)
         remote_paths = list(
-            eti_ftp.listdir(config.host, remote_path, valid_compara_homology()),
+            eti_ftp.listdir(site_map.site, remote_path, valid_compara_homology()),
         )
         if verbose:
             print(f"{remote_path=}", f"{remote_paths=}", sep="\n")
@@ -316,7 +318,7 @@ def download_homology(
         local_dir.mkdir(parents=True, exist_ok=True)
         _remove_tmpdirs(local_dir)
         eti_ftp.download_data(
-            host=config.host,
+            host=site_map.site,
             local_dest=local_dir,
             remote_paths=remote_paths,
             description=f"{db_name[:10]}...",

--- a/src/ensembl_tui/_ingest_annotation.py
+++ b/src/ensembl_tui/_ingest_annotation.py
@@ -278,6 +278,8 @@ def make_combined_tables(
     *,
     config: eti_config.Config,
     db_name: str,
+    genome_name: str | None = None,
+    is_multi_genome: bool = False,
     cleanup: bool = True,
 ) -> None:
     """makes combined tables for transcripts and genes and writes as parquet files
@@ -287,7 +289,13 @@ def make_combined_tables(
     config
         an downloaed cfg instance
     db_name
-        directory name reprsenting a species
+        directory name representing a species (used for output paths)
+    genome_name
+        the actual genome name for filtering in multi-genome databases.
+        If is_multi_genome=True, this is used to query the meta table.
+    is_multi_genome
+        if True, filter tables by species_id from meta table and overwrite
+        coord_system.parquet and seq_region.parquet with filtered versions
     cleanup
         if provided, the parquet files from which merged tables are built
         are deleted on completion
@@ -295,8 +303,14 @@ def make_combined_tables(
     Notes
     -----
     Creates transcript_attr.parquet and gene_attr.parquet files.
+    For multi-genome databases, also filters and overwrites coord_system.parquet
+    and seq_region.parquet to contain only single-species data.
     """
-    from ensembl_tui._mysql_core_attr import make_gene_attr, make_transcript_attr
+    from ensembl_tui._mysql_core_attr import (
+        get_species_coord_system_ids,
+        make_gene_attr,
+        make_transcript_attr,
+    )
 
     # make the transcribed_attr table
     transcribed_tables = (
@@ -309,9 +323,51 @@ def make_combined_tables(
         "seq_region",
         "coord_system",
     )  # keep these one separate as we need them for repeats
+
+    # Add meta table if multi-genome
+    if is_multi_genome:
+        all_tables = transcribed_tables + preserve + ("meta",)
+    else:
+        all_tables = transcribed_tables + preserve
+
     # checks these tables already exist in parquet format, fails otherwise
-    conn = _make_db(config, db_name, transcribed_tables + preserve)
-    _ = make_transcript_attr(con=conn)
+    conn = _make_db(config, db_name, all_tables)
+
+    # Get coord_system_ids if filtering needed
+    coord_system_ids = None
+    if is_multi_genome and genome_name:
+        coord_system_ids = get_species_coord_system_ids(conn, genome_name)
+
+        # Filter and overwrite coord_system.parquet with single-species data
+        ids_str = ",".join(str(i) for i in coord_system_ids)
+        sql = f"CREATE TABLE coord_system_filtered AS SELECT * FROM coord_system WHERE coord_system_id IN ({ids_str})"
+        conn.sql(sql)
+        export_parquet(
+            con=conn,
+            table_name="coord_system_filtered",
+            dest_dir=config.install_genomes / db_name,
+        )
+        # Rename to replace original coord_system.parquet
+        filtered_path = (
+            config.install_genomes / db_name / "coord_system_filtered.parquet"
+        )
+        original_path = config.install_genomes / db_name / "coord_system.parquet"
+        filtered_path.rename(original_path)
+
+        # Filter and overwrite seq_region.parquet with single-species data
+        sql = f"CREATE TABLE seq_region_filtered AS SELECT * FROM seq_region WHERE coord_system_id IN ({ids_str})"
+        conn.sql(sql)
+        export_parquet(
+            con=conn,
+            table_name="seq_region_filtered",
+            dest_dir=config.install_genomes / db_name,
+        )
+        # Rename to replace original seq_region.parquet
+        filtered_path = config.install_genomes / db_name / "seq_region_filtered.parquet"
+        original_path = config.install_genomes / db_name / "seq_region.parquet"
+        filtered_path.rename(original_path)
+
+    _ = make_transcript_attr(con=conn, coord_system_ids=coord_system_ids)
     export_parquet(
         con=conn,
         table_name="transcript_attr",
@@ -320,8 +376,18 @@ def make_combined_tables(
     conn.close()
     # make the gene_attr table
     gene_tables = "gene", "xref"
-    conn = _make_db(config, db_name, gene_tables + preserve)
-    _ = make_gene_attr(con=conn)
+    if is_multi_genome:
+        all_tables = gene_tables + preserve + ("meta",)
+    else:
+        all_tables = gene_tables + preserve
+
+    conn = _make_db(config, db_name, all_tables)
+
+    # Get coord_system_ids again (new connection)
+    if is_multi_genome and genome_name:
+        coord_system_ids = get_species_coord_system_ids(conn, genome_name)
+
+    _ = make_gene_attr(con=conn, coord_system_ids=coord_system_ids)
     export_parquet(
         con=conn,
         table_name="gene_attr",
@@ -329,7 +395,11 @@ def make_combined_tables(
     )
     conn.close()
     if cleanup:
-        for table_name in transcribed_tables + gene_tables:
+        cleanup_tables = list(transcribed_tables + gene_tables)
+        # Add meta table to cleanup if multi-genome
+        if is_multi_genome:
+            cleanup_tables.append("meta")
+        for table_name in cleanup_tables:
             (config.install_genomes / db_name / f"{table_name}.parquet").unlink(
                 missing_ok=True,
             )
@@ -356,14 +426,23 @@ class mysql_dump_to_parquet:  # noqa: N801
         self._verbose = verbose
         self._make_combined = make_combined
 
-    def main(self, db_name: str) -> pathlib.Path:
-        dump_dir = self._staging_dir / db_name / "mysql"
+    def main(self, genome_name: str) -> pathlib.Path:
+        db_name = self._config.species_map.get_ensembl_db_prefix(genome_name)
+        is_multi_genome = db_name != genome_name  # Detection logic
+
+        if is_multi_genome:
+            dump_dir = self._staging_dir / db_name / "mysql"
+        else:
+            dump_dir = self._staging_dir / genome_name / "mysql"
+
         if not dump_dir.exists():
-            msg = f"no mysql dump dir for {db_name}"
+            msg = f"no mysql dump dir for {genome_name}"
             raise FileNotFoundError(msg)
 
-        dest_dir = self._install_dir / db_name
+        dest_dir = self._install_dir / genome_name
         dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Import all tables to parquet (no filtering here - write_parquet unchanged)
         for table_name in self._table_names:
             dump_path = dump_dir / f"{table_name}.txt.gz"
             if not dump_path.exists():
@@ -377,8 +456,14 @@ class mysql_dump_to_parquet:  # noqa: N801
                 dest_dir=dest_dir,
             )
 
-        # and now we construct the combined attr tables
+        # Create combined tables with filtering if needed
         if self._make_combined:
-            make_combined_tables(config=self._config, db_name=db_name, cleanup=True)
+            make_combined_tables(
+                config=self._config,
+                db_name=genome_name,  # Output directory name
+                genome_name=genome_name if is_multi_genome else None,
+                is_multi_genome=is_multi_genome,
+                cleanup=True,
+            )
 
         return dest_dir

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -22,12 +22,12 @@ def local_install_genomes(
     # we create the local installation
     config.install_genomes.mkdir(parents=True, exist_ok=True)
     # we create subdirectories for each species
-    for db_name in list(config.db_names):
+    db_names = [config.species_map.get_genome_name(sp) for sp in config.species_dbs]
+    for db_name in db_names:
         sp_dir = config.install_genomes / db_name
         sp_dir.mkdir(parents=True, exist_ok=True)
 
     # for each species, we identify the download and dest paths for annotations
-    db_names = list(config.db_names)
     if max_workers:
         max_workers = min(len(db_names) + 1, max_workers)
 

--- a/src/ensembl_tui/_mysql_core_attr.py
+++ b/src/ensembl_tui/_mysql_core_attr.py
@@ -75,6 +75,10 @@ def load_db(db_name: pathlib.Path, table_names: set[str]) -> duckdb.DuckDBPyConn
     return con
 
 
+species_attrs = {
+    "species_name": "meta",
+}
+
 location_attrs = {
     "location": "seq_region",
     "coord_system": "coord_system",
@@ -115,6 +119,52 @@ def make_mysqldump_names() -> list[str]:
     all_tables = [f"{table}.txt.gz" for table in get_all_tables()]
     all_tables.insert(0, "CHECKSUMS")
     return all_tables
+
+
+def get_species_coord_system_ids(
+    conn: duckdb.DuckDBPyConnection,
+    genome_name: str,
+) -> list[int]:
+    """Get coord_system_id values for a specific genome in a multi-genome database.
+
+    Parameters
+    ----------
+    conn
+        DuckDB connection with meta and coord_system tables loaded
+    genome_name
+        The genome name to filter by (e.g., 'homo_sapiens')
+
+    Returns
+    -------
+    List of coord_system_id values for this species
+
+    Raises
+    ------
+    ValueError
+        If no species_id found for the given genome_name
+    """
+    # Step 1: Get species_id from meta table
+    sql = """
+    SELECT species_id
+    FROM meta
+    WHERE meta_key = 'species.db_name'
+    AND meta_value = ?
+    """
+    result = conn.execute(sql, [genome_name]).fetchone()
+    if not result:
+        msg = f"No species_id found in meta table for genome_name={genome_name}"
+        raise ValueError(msg)
+
+    species_id = result[0]
+
+    # Step 2: Get coord_system_id values for this species_id
+    sql = """
+    SELECT coord_system_id
+    FROM coord_system
+    WHERE species_id = ?
+    """
+    results = conn.execute(sql, [species_id]).fetchall()
+    return [r[0] for r in results]
 
 
 # we integrate transcript groups of tables into the following:
@@ -408,9 +458,27 @@ def get_transcript_attr_records(
     return
 
 
-def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
-    """creates a transcript_attr table from several other tables"""
-    sql = """CREATE VIEW IF NOT EXISTS exon_view AS
+def make_transcript_attr(
+    con: duckdb.DuckDBPyConnection,
+    coord_system_ids: list[int] | None = None,
+) -> duckdb.DuckDBPyConnection:
+    """creates a transcript_attr table from several other tables
+
+    Parameters
+    ----------
+    con
+        DuckDB connection
+    coord_system_ids
+        If provided, filter to only these coord_system_id values
+        (for multi-genome databases). If None, no filtering applied.
+    """
+    # Build WHERE clause if filtering needed
+    where_clause = ""
+    if coord_system_ids is not None:
+        ids_str = ",".join(str(i) for i in coord_system_ids)
+        where_clause = f"WHERE cs.coord_system_id IN ({ids_str})"
+
+    sql = f"""CREATE VIEW IF NOT EXISTS exon_view AS
         SELECT
             et.transcript_id AS transcript_id,
             ex.exon_id AS exon_id,
@@ -432,6 +500,7 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
         JOIN exon_transcript et ON ex.exon_id = et.exon_id
         JOIN transcript tr ON et.transcript_id = tr.transcript_id
         LEFT JOIN translation tl ON tr.transcript_id = tl.transcript_id
+        {where_clause}
         """
     # it's a left join between tr and tl to handle the case where
     # there is no translation and thus a transcript_id is missing from tl
@@ -449,10 +518,28 @@ def make_transcript_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConne
     return con
 
 
-def make_gene_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
-    """creates a gene_attr 'table' from several other tables"""
+def make_gene_attr(
+    con: duckdb.DuckDBPyConnection,
+    coord_system_ids: list[int] | None = None,
+) -> duckdb.DuckDBPyConnection:
+    """creates a gene_attr 'table' from several other tables
+
+    Parameters
+    ----------
+    con
+        DuckDB connection
+    coord_system_ids
+        If provided, filter to only these coord_system_id values
+        (for multi-genome databases). If None, no filtering applied.
+    """
+    # Build WHERE clause if filtering needed
+    where_clause = ""
+    if coord_system_ids is not None:
+        ids_str = ",".join(str(i) for i in coord_system_ids)
+        where_clause = f"WHERE cs.coord_system_id IN ({ids_str})"
+
     # need to also add coord_system_name to the gene_attr table
-    sql = """CREATE VIEW IF NOT EXISTS gene_attr AS
+    sql = f"""CREATE VIEW IF NOT EXISTS gene_attr AS
         SELECT
             g.gene_id AS gene_id,
             g.stable_id AS stable_id,
@@ -469,6 +556,7 @@ def make_gene_attr(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
         JOIN seq_region sr ON g.seq_region_id = sr.seq_region_id
         JOIN coord_system cs ON sr.coord_system_id = cs.coord_system_id
         LEFT JOIN xref x ON g.display_xref_id = x.xref_id
+        {where_clause}
         """
     con.sql(sql)
     return con

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -113,6 +113,21 @@ def ensembl_metazoa_sitemap() -> SiteMap:
     )
 
 
+@register_ensembl_site_map("protists")
+def ensembl_metazoa_sitemap() -> SiteMap:
+    """the metazoa Ensembl site map"""
+    return SiteMap(
+        site="ftp.ensemblgenomes.org",
+        _alignments_path=None,
+        _homologies_path="tsv/ensembl-compara/homologies",
+        _trees_path=None,
+        db_host="mysql-eg-publicsql.ebi.ac.uk",
+        db_port=4157,
+        remote_path="pub/protists",
+        species_file_name="species_EnsemblProtists.txt",
+    )
+
+
 # for bacteria we have, but complexities related to the bacterial collection
 # a species belongs to. For example
 # https://ftp.ensemblgenomes.ebi.ac.uk/pub/bacteria/release-57/fasta/bacteria_15_collection/_butyribacterium_methylotrophicum_gca_001753695/dna/

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -56,8 +56,13 @@ class SiteMap:
     _homologies_path: str | None = None
     _trees_path: str | None = None
 
-    def get_seqs_path(self, ensembl_name: str) -> str:
+    def get_seqs_path(self, ensembl_name: str, collection_name: str | None) -> str:
         """path to unmasked genome sequences"""
+        # this needs to be self._seqs_path/ensembl_name/dna
+        # except when it's part of a collection, in which case its
+        # self._seqs_path/collection_name/ensembl_name/dna
+        if collection_name:
+            return f"{self._seqs_path}/{collection_name}/{ensembl_name}/dna"
         return f"{self._seqs_path}/{ensembl_name}/dna"
 
     def get_annotations_path(self, ensembl_name: str) -> str:
@@ -114,8 +119,8 @@ def ensembl_metazoa_sitemap() -> SiteMap:
 
 
 @register_ensembl_site_map("protists")
-def ensembl_metazoa_sitemap() -> SiteMap:
-    """the metazoa Ensembl site map"""
+def ensembl_protists_sitemap() -> SiteMap:
+    """the protists Ensembl site map"""
     return SiteMap(
         site="ftp.ensemblgenomes.org",
         _alignments_path=None,

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -141,10 +141,27 @@ def ensembl_metazoa_sitemap() -> SiteMap:
 
 @cache
 def get_site_map(domain: str) -> SiteMap:
-    """returns a site map instance"""
+    """Returns a site map instance for the specified domain.
+
+    Parameters
+    ----------
+    domain : str
+        The Ensembl domain name (e.g., 'main', 'vertebrates', 'metazoa', 'protists').
+        Use get_site_map_names() to see all available options.
+
+    Returns
+    -------
+    SiteMap
+        Site configuration containing FTP host, database connection info, and paths.
+
+    Raises
+    ------
+    KeyError
+        If the domain is not registered.
+    """
     return _ensembl_site_map[domain]()
 
 
 def get_site_map_names() -> list[str]:
-    """returns the registered site map names"""
+    """Returns all registered Ensembl domain names."""
     return list(_ensembl_site_map)

--- a/src/ensembl_tui/_species.py
+++ b/src/ensembl_tui/_species.py
@@ -173,7 +173,7 @@ class SpeciesNameMap:
         """returns cogent3 Table"""
         rows = [
             [abrv, self._abrv_to_common[abrv], self._abrv_to_genome[abrv], db_prefix]
-            for db_prefix, abrv in self._db_to_abrv.items()
+            for abrv, db_prefix in self._abrv_to_db.items()
         ]
         return make_table(
             header=TABLE_COLUMNS,

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -109,10 +109,15 @@ def download(
         )
         sys.exit(1)
 
-    config = eti_config.read_config(
-        config_path=configpath, root_dir=pathlib.Path.cwd(), species_map=species_map
-    )
-    site_map = eti_site_map.get_site_map(config.host)
+    try:
+        config = eti_config.read_config(
+            config_path=configpath, root_dir=pathlib.Path.cwd(), species_map=species_map
+        )
+    except ValueError as e:
+        eti_util.print_colour(text=str(e), colour="red", style="bold")
+        sys.exit(1)
+
+    site_map = eti_site_map.get_site_map(config.domain)
 
     if verbose:
         eti_util.print_colour(text=str(config), colour="yellow")

--- a/src/ensembl_tui/data/sample.cfg
+++ b/src/ensembl_tui/data/sample.cfg
@@ -1,6 +1,7 @@
 [remote path]
 # Specify which Ensembl domain to get the data from.
-host=ftp.ensembl.org
+# Available domains: main, vertebrates, metazoa, protists
+domain=main
 [local path]
 # Local paths correspond to where the data will be downloaded
 # and where the installation will be placed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,24 @@ def tmp_config_just_yeast(tmp_dir):
     return download_cfg
 
 
+@pytest.fixture
+def tmp_config_domain_format(tmp_dir):
+    """Config using new 'domain' format instead of 'host'"""
+    parser = ConfigParser()
+    parser.read(eti_util.get_resource_path("sample.cfg"))
+    # Remove host, add domain
+    parser.remove_option("remote path", "host")
+    parser.set("remote path", "domain", value="main")
+    parser.remove_section("Caenorhabditis elegans")
+    parser.remove_section("compara")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    download_cfg = tmp_dir / "download_domain.cfg"
+    with open(download_cfg, "w") as out:
+        parser.write(out)
+    return download_cfg
+
+
 def name_as_seqid(species, seqid, start, end):  # noqa: ARG001
     return seqid
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -491,7 +491,7 @@ def db_align(DATA_DIR, tmp_dir):
     install_path = tmp_dir / "install"
 
     cfg = eti_config.Config(
-        host="localhost",
+        domain="main",
         staging_path=staging_path,
         install_path=install_path,
         species_dbs={},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,3 +205,142 @@ def test_read_config_genomes(cfg_just_genomes, default_species_map):
     config = eti_config.read_config(config_path=cfg_just_genomes)
     expected = {default_species_map.get_genome_name(n) for n in COMMON_NAMES}
     assert set(config.species_dbs.keys()) == expected
+
+
+def test_read_config_with_domain(tmp_config_domain_format):
+    """Test reading config with new 'domain' option"""
+    config = eti_config.read_config(config_path=tmp_config_domain_format)
+    assert config.domain == "main"  # Domain stores user's choice
+
+
+def test_read_config_with_host_shows_deprecation(tmp_dir):
+    """Test that using 'host' triggers deprecation warning"""
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read(eti_util.get_resource_path("sample.cfg"))
+    # Remove domain, add host (to simulate old config format)
+    parser.remove_option("remote path", "domain")
+    parser.set("remote path", "host", value="ftp.ensembl.org")
+    parser.remove_section("Caenorhabditis elegans")
+    parser.remove_section("compara")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    cfg_path = tmp_dir / "old_format.cfg"
+    with open(cfg_path, "w") as out:
+        parser.write(out)
+
+    with pytest.warns(DeprecationWarning, match="'host' option.*deprecated"):
+        config = eti_config.read_config(config_path=cfg_path)
+    assert config.domain == "ftp.ensembl.org"  # domain set from host
+
+
+def test_domain_takes_precedence_over_host(tmp_dir):
+    """Test that 'domain' takes precedence when both present"""
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read(eti_util.get_resource_path("sample.cfg"))
+    parser.set("remote path", "domain", value="metazoa")
+    parser.set("remote path", "host", value="ftp.ensembl.org")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    parser.remove_section("Caenorhabditis elegans")
+    parser.remove_section("compara")
+    cfg_path = tmp_dir / "both.cfg"
+    with open(cfg_path, "w") as out:
+        parser.write(out)
+
+    with pytest.warns(DeprecationWarning):
+        config = eti_config.read_config(config_path=cfg_path)
+    assert config.domain == "metazoa"  # domain from config file
+
+
+def test_invalid_domain_raises(tmp_dir):
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read(eti_util.get_resource_path("sample.cfg"))
+    parser.remove_option("remote path", "host")
+    parser.set("remote path", "domain", value="invalid_domain")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    parser.remove_section("Caenorhabditis elegans")
+    parser.remove_section("compara")
+    cfg_path = tmp_dir / "invalid.cfg"
+    with open(cfg_path, "w") as out:
+        parser.write(out)
+
+    with pytest.raises(ValueError):
+        eti_config.read_config(config_path=cfg_path)
+
+
+def test_missing_both_domain_and_host_raises(tmp_dir):
+    """Test that missing both domain and host causes clear error"""
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read(eti_util.get_resource_path("sample.cfg"))
+    parser.remove_option("remote path", "domain")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    parser.remove_section("Caenorhabditis elegans")
+    parser.remove_section("compara")
+    cfg_path = tmp_dir / "missing.cfg"
+    with open(cfg_path, "w") as out:
+        parser.write(out)
+
+    with pytest.raises(ValueError):
+        eti_config.read_config(config_path=cfg_path)
+
+
+def test_write_config_uses_domain_not_host(tmp_config_domain_format):
+    """Test that Config.write() writes 'domain' not 'host'"""
+    import configparser
+
+    config = eti_config.read_config(config_path=tmp_config_domain_format)
+    config.write()
+
+    # Read back the written config
+    parser = configparser.ConfigParser()
+    written_path = config.staging_path / eti_config.DOWNLOADED_CONFIG_NAME
+    parser.read(written_path)
+
+    # Should have 'domain' and NOT 'host'
+    assert parser.has_option("remote path", "domain")
+    assert not parser.has_option("remote path", "host")
+
+
+@pytest.mark.parametrize(
+    ("domain", "expected_host"),
+    [
+        ("main", "ftp.ensembl.org"),
+        ("vertebrates", "ftp.ensembl.org"),
+        ("ftp.ensembl.org", "ftp.ensembl.org"),
+        ("metazoa", "ftp.ensemblgenomes.org"),
+        ("ftp.ensemblgenomes.org", "ftp.ensemblgenomes.org"),
+        ("protists", "ftp.ensemblgenomes.org"),
+    ],
+)
+def test_all_registered_domains_work(tmp_dir, domain, expected_host):
+    """Test that all registered domains can be used in config"""
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.add_section("remote path")
+    parser.set("remote path", "domain", value=domain)
+    parser.add_section("local path")
+    parser.set("local path", "staging_path", value=str(tmp_dir / "staging"))
+    parser.set("local path", "install_path", value=str(tmp_dir / "install"))
+    parser.add_section("release")
+    parser.set("release", "release", value="115")
+    parser.add_section("Saccharomyces cerevisiae")
+    parser.set("Saccharomyces cerevisiae", "db", value="core")
+
+    cfg_path = tmp_dir / f"test_{domain.replace('.', '_')}.cfg"
+    with open(cfg_path, "w") as out:
+        parser.write(out)
+
+    # Should not raise
+    config = eti_config.read_config(config_path=cfg_path)
+    assert config.domain == domain  # Domain stores user's choice

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,7 +10,7 @@ from ensembl_tui import _site_map as eti_smap
 @pytest.mark.timeout(10)
 def test_get_db_names(tmp_config_just_yeast, ENSEMBL_RELEASE_VERSION):
     cfg = eti_config.read_config(config_path=tmp_config_just_yeast)
-    db_names = eti_download.get_core_db_dirnames(cfg)
+    db_names = eti_download.get_core_db_dirnames(cfg, eti_smap.get_site_map("main"))
     assert db_names == {
         "saccharomyces_cerevisiae": f"pub/release-{ENSEMBL_RELEASE_VERSION}/mysql/saccharomyces_cerevisiae_core_{ENSEMBL_RELEASE_VERSION}_4",
     }

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -3,7 +3,7 @@ import pytest
 from ensembl_tui import _site_map as eti_smap
 
 
-@pytest.mark.parametrize("site", ("ftp.ensembl.org",))
+@pytest.mark.parametrize("site", ["ftp.ensembl.org"])
 def test_correct_site(site):
     smap = eti_smap.get_site_map(site)
     assert smap.site == site
@@ -11,7 +11,7 @@ def test_correct_site(site):
 
 def test_standard_smp():
     sm = eti_smap.get_site_map("ftp.ensembl.org")
-    assert sm.get_seqs_path("abcd") == "fasta/abcd/dna"
+    assert sm.get_seqs_path("abcd", collection_name=None) == "fasta/abcd/dna"
     assert sm.get_annotations_path("abcd") == "mysql/abcd"
 
 
@@ -28,7 +28,7 @@ def test_get_default_site_map_species():
     assert smap.species_file_name == "species_EnsemblVertebrates.txt"
 
 
-@pytest.mark.parametrize("site", ("main", "metazoa"))
+@pytest.mark.parametrize("site", ["main", "metazoa"])
 def test_get_remote_path(site):
     smap = eti_smap.get_site_map(site)
     release = "62"


### PR DESCRIPTION
## Summary by Sourcery

Support domain-based configuration and multi-genome collections while extending site map coverage and keeping backward compatibility with existing configs.

New Features:
- Allow configuration of Ensembl FTP access via named domains (e.g. main, metazoa, protists) instead of raw hosts, including validation and mapping to site maps.
- Add support for multi-genome (collection) databases in the annotation ingestion pipeline by filtering coord_system and seq_region tables per genome and wiring genome-aware paths throughout.
- Expose additional annotation DB helpers (record fetching, compatibility, close) on composite annotation types, aligning their interfaces with underlying SQLite DBs.
- Register a new protists Ensembl site map and extend sequence path handling to support collection-based genome layouts.

Bug Fixes:
- Fix species table construction to use the correct abbreviation-to-DB mapping, ensuring consistent species metadata.
- Ensure local installation directories are created per genome name rather than raw DB name for species DBs.

Enhancements:
- Refactor configuration handling to store domain instead of host, derive core DB names from the species map, and return clearer errors from the CLI on invalid config.
- Update download logic to take an explicit site map, use domain-based sites, and correctly construct remote/local paths and descriptions for both single genomes and collections.
- Extend combined attribute table builders to optionally filter by coord_system_id derived from the meta table, making them safe for multi-genome databases.
- Improve site map utilities with richer documentation and helper functions for discovering available domains.
- Add missing interface methods (get_records_matching, compatible, close) to composite annotation DB wrappers for better interoperability.

Build:
- Bump Python compatibility to include 3.14 and refresh core dependencies (cogent3, cogent3-h5seqs, ruff), while reformatting pyproject metadata for consistency.
- Expand nox test matrix to cover Python 3.14 and tidy pyproject tool configuration formatting.

Documentation:
- Update the bundled sample.cfg to document domain-based configuration and the available Ensembl domains.

Tests:
- Add comprehensive tests for new domain-based configuration, deprecation and precedence of host vs domain, and validation of registered domains.
- Update existing tests to use domain-based site maps, new sequence-path signatures, and adjusted Config semantics.
- Introduce a fixture for generating temporary domain-style configs and align tests with new site map registration (including protists).