### PR TITLE
MAINT: tidying cfg files etc...

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -37,7 +37,7 @@ This is a `.ini` format. A section is denoted by square brackets surrounding the
 
 ### `[remote path]`
 
-This is the section defining which Ensembl FTP server hosts the data.
+This is the section defining which Ensembl domain hosts the data you want, e.g. main, metazoa, protists.
 
 ### `[local path]`
 
@@ -84,7 +84,7 @@ For example, the following config would download 10 primate genomes along with w
 
 ```ini
 [remote path]
-host=ftp.ensembl.org
+domain=main
 [local path]
 staging_path=download_115
 install_path=install_115
@@ -92,7 +92,7 @@ install_path=install_115
 release=115
 [compara]
 align_names=10_primates.epo
-homologies =
+homologies=
 ```
 
 ```bash exec="1" workdir="./docs"

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -380,29 +380,16 @@ def _validate_and_resolve_domain(remote_section: dict[str, str]) -> tuple[str, s
         raise ValueError(msg)
 
     # Precedence: domain takes priority if both present
-    if host_value or (domain_value and host_value):
-        if host_value:
-            msg = "The 'host' option in [remote path] is deprecated. Please use 'domain' instead. "
-            "Support for 'host' will be removed in a future version."
-        else:
-            msg = "Both 'domain' and 'host' found in [remote path]. Using 'domain' value. "
-            "The 'host' option is deprecated and will be removed in a future version."
+    if host_value:
+        msg = "The 'host' option in [remote path] is deprecated. Please use 'domain' instead. "
         warnings.warn(
             msg,
             DeprecationWarning,
             stacklevel=3,
         )
         domain = domain_value or host_value
-    elif domain_value:
-        domain = domain_value
     else:
-        # This case should not occur due to earlier validation
-        eti_util.print_colour(
-            "Config error: Unable to determine domain from [remote path] section",
-            colour="red",
-        )
-        sys.exit(1)
-
+        domain = domain_value
     # Validate domain exists in site map registry
     available = eti_site_map.get_site_map_names()
     if domain not in available:

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -379,9 +379,8 @@ def _validate_and_resolve_domain(remote_section: dict[str, str]) -> tuple[str, s
         )
         raise ValueError(msg)
 
-    # Precedence: domain takes priority if both present
     if host_value:
-        msg = "The 'host' option in [remote path] is deprecated. Please use 'domain' instead. "
+        msg = "The 'host' option in [remote path] is deprecated, use 'domain' instead."
         warnings.warn(
             msg,
             DeprecationWarning,

--- a/tests/data/prep_tests_data/apes.cfg
+++ b/tests/data/prep_tests_data/apes.cfg
@@ -1,6 +1,6 @@
 [remote path]
 path = pub
-host = ftp.ensembl.org
+domain = main
 [local path]
 staging_path = apes-115-download
 install_path = apes-115

--- a/tests/data/small.cfg
+++ b/tests/data/small.cfg
@@ -1,5 +1,5 @@
 [remote path]
-host=ftp.ensembl.org
+domain=main
 [local path]
 staging_path=small-115/download
 install_path=small-115/install

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,17 +302,17 @@ def test_write_config_uses_domain_not_host(tmp_config_domain_format):
 
 
 @pytest.mark.parametrize(
-    ("domain", "expected_host"),
+    "domain",
     [
-        ("main", "ftp.ensembl.org"),
-        ("vertebrates", "ftp.ensembl.org"),
-        ("ftp.ensembl.org", "ftp.ensembl.org"),
-        ("metazoa", "ftp.ensemblgenomes.org"),
-        ("ftp.ensemblgenomes.org", "ftp.ensemblgenomes.org"),
-        ("protists", "ftp.ensemblgenomes.org"),
+        "main",
+        "vertebrates",
+        "ftp.ensembl.org",
+        "metazoa",
+        "ftp.ensemblgenomes.org",
+        "protists",
     ],
 )
-def test_all_registered_domains_work(tmp_dir, domain, expected_host):
+def test_all_registered_domains_work(tmp_dir, domain):
     """Test that all registered domains can be used in config"""
     parser = configparser.ConfigParser()
     parser.add_section("remote path")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,8 +215,6 @@ def test_read_config_with_domain(tmp_config_domain_format):
 
 def test_read_config_with_host_shows_deprecation(tmp_dir):
     """Test that using 'host' triggers deprecation warning"""
-    import configparser
-
     parser = configparser.ConfigParser()
     parser.read(eti_util.get_resource_path("sample.cfg"))
     # Remove domain, add host (to simulate old config format)
@@ -237,8 +235,6 @@ def test_read_config_with_host_shows_deprecation(tmp_dir):
 
 def test_domain_takes_precedence_over_host(tmp_dir):
     """Test that 'domain' takes precedence when both present"""
-    import configparser
-
     parser = configparser.ConfigParser()
     parser.read(eti_util.get_resource_path("sample.cfg"))
     parser.set("remote path", "domain", value="metazoa")
@@ -257,8 +253,6 @@ def test_domain_takes_precedence_over_host(tmp_dir):
 
 
 def test_invalid_domain_raises(tmp_dir):
-    import configparser
-
     parser = configparser.ConfigParser()
     parser.read(eti_util.get_resource_path("sample.cfg"))
     parser.remove_option("remote path", "host")
@@ -277,8 +271,6 @@ def test_invalid_domain_raises(tmp_dir):
 
 def test_missing_both_domain_and_host_raises(tmp_dir):
     """Test that missing both domain and host causes clear error"""
-    import configparser
-
     parser = configparser.ConfigParser()
     parser.read(eti_util.get_resource_path("sample.cfg"))
     parser.remove_option("remote path", "domain")
@@ -296,8 +288,6 @@ def test_missing_both_domain_and_host_raises(tmp_dir):
 
 def test_write_config_uses_domain_not_host(tmp_config_domain_format):
     """Test that Config.write() writes 'domain' not 'host'"""
-    import configparser
-
     config = eti_config.read_config(config_path=tmp_config_domain_format)
     config.write()
 
@@ -324,8 +314,6 @@ def test_write_config_uses_domain_not_host(tmp_config_domain_format):
 )
 def test_all_registered_domains_work(tmp_dir, domain, expected_host):
     """Test that all registered domains can be used in config"""
-    import configparser
-
     parser = configparser.ConfigParser()
     parser.add_section("remote path")
     parser.set("remote path", "domain", value=domain)


### PR DESCRIPTION
## Summary by Sourcery

Update configuration handling to prefer the new 'domain' option while keeping deprecation support for 'host', and align tests and documentation with the domain-based configuration format.

Enhancements:
- Simplify remote domain resolution logic to consistently warn on deprecated 'host' usage while defaulting to 'domain' where present.

Documentation:
- Refresh configuration documentation and examples to describe and demonstrate the 'domain' option instead of 'host' and tidy formatting.

Tests:
- Update test configuration files and clean up redundant imports in config tests to reflect the domain-based configuration format.