### PR TITLE
MAINT: address resource warnings in tests

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -200,6 +200,7 @@ def test_building_alignment(genomedbs_aligndb, namer):
     )
     orig = small_seqs()[1:5]
     assert got.to_dict() == orig.to_dict()
+    got.annotation_db.close()
 
 
 @pytest.mark.parametrize(
@@ -351,6 +352,8 @@ def test_select_alignment_minus_strand(start_end, namer):
     elif start != None == end:  # noqa E711
         end = len(s2) - s2_ft.map.start
         start = None
+
+    aln.annotation_db.close()
 
     # mouse sequence is on minus strand, so need to adjust
     # coordinates for query

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,7 +91,8 @@ def installed_aligns(tmp_path, default_species_map):
     for name in names:
         dirname = align_dir / name
         dirname.mkdir(parents=True, exist_ok=True)
-        (dirname / f"align_blocks.{eti_align.ALIGN_STORE_SUFFIX}").open(mode="w")
+        db = (dirname / f"align_blocks.{eti_align.ALIGN_STORE_SUFFIX}").open(mode="w")
+        db.close()
     return eti_config.InstalledConfig(
         release="11",
         install_path=tmp_path,


### PR DESCRIPTION
## Summary by Sourcery

Close alignment-related resources in tests to prevent resource warnings during test execution.

Bug Fixes:
- Ensure alignment annotation databases are explicitly closed after use in alignment tests to avoid resource leaks and warnings.

Tests:
- Explicitly close temporary alignment database files created in tests to prevent resource warning noise and potential file handle leaks.