### PR TITLE
DEV: bump version to 0.7.0

### DIFF
--- a/src/ensembl_tui/__init__.py
+++ b/src/ensembl_tui/__init__.py
@@ -6,4 +6,4 @@ filterwarnings("ignore", message=".*MPI")
 filterwarnings("ignore", message="Can't drop database.*")
 filterwarnings("ignore", message="A worker stopped while some jobs.*")
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -133,14 +133,6 @@ def ensembl_protists_sitemap() -> SiteMap:
     )
 
 
-# for bacteria we have, but complexities related to the bacterial collection
-# a species belongs to. For example
-# https://ftp.ensemblgenomes.ebi.ac.uk/pub/bacteria/release-57/fasta/bacteria_15_collection/_butyribacterium_methylotrophicum_gca_001753695/dna/
-# so to address this, the sitemap class needs to download the species table from ensembl bacteria
-# and cache the collection/species mapping
-# site = "ftp.ensemblgenomes.ebi.ac.uk",
-# _genomes_path = "fasta",
-# _annotations_path = "gff3",
 # _homologies_path = "pan_ensembl/tsv/ensembl-compara/homologies",
 
 

--- a/src/ensembl_tui/_storage_mixin.py
+++ b/src/ensembl_tui/_storage_mixin.py
@@ -24,7 +24,7 @@ def _(data: bytes) -> bytes:
 
 
 @functools.singledispatch
-def blob_to_array(data: bytes) -> numpy.ndarray:
+def blob_to_array(data: bytes | numpy.ndarray) -> numpy.ndarray:
     with io.BytesIO(data) as out:
         out.seek(0)
         return numpy.load(out)


### PR DESCRIPTION
## Summary by Sourcery

Bump the library version and broaden storage utilities to accept pre-existing NumPy arrays.

Enhancements:
- Allow blob_to_array to accept either raw bytes or an existing NumPy array as input.
- Remove obsolete commented-out notes about future bacteria sitemap support.

Chores:
- Update the package version constant to 0.7.0.