### PR TITLE
ENH: now works with protists data properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ Some commands can be run in parallel but have moderate memory requirements. If y
     exports sample config and species table to the nominated path
 
   Options:
-    -o, --outpath PATH     Path to directory to export all rc contents.
-    -f, --force_overwrite  Overwrite existing data.
-    --help                 Show this message and exit.
+    -o, --outpath PATH              Path to directory to export all rc contents.
+    --domain [vertebrates|main|metazoa|protists]
+                                    Ensembl domain to use for species list.
+                                    [default: main]
+    -f, --force_overwrite           Overwrite existing data.
+    --help                          Show this message and exit.
 
   ```
   <!-- [[[end]]] -->
@@ -109,12 +112,14 @@ Some commands can be run in parallel but have moderate memory requirements. If y
     download data from Ensembl's ftp site
 
   Options:
-    -c, --configpath PATH  Path to config file specifying databases, (only species
-                           or compara at present).
-    -d, --debug            Maximum verbosity, and reduces number of downloads,
-                           etc...
+    -c, --configpath PATH    Path to config file specifying databases, (only
+                             species or compara at present).
+    -d, --debug              Maximum verbosity, and reduces number of downloads,
+                             etc...
+    -sm, --species_map TEXT  Tsv file with species names, abbreviations etc..
+                             [default: main]
     -v, --verbose
-    --help                 Show this message and exit.
+    --help                   Show this message and exit.
 
   ```
   <!-- [[[end]]] -->

--- a/src/ensembl_tui/_cli_option.py
+++ b/src/ensembl_tui/_cli_option.py
@@ -299,11 +299,11 @@ nprocs = click.option(
     help="Number of procs to use.",
     show_default=True,
 )
-site = click.option(
-    "--site",
+domain = click.option(
+    "--domain",
     default="main",
     type=click.Choice(eti_site_map.get_site_map_names(), case_sensitive=False),
-    help="Ensembl site to use for species list.",
+    help="Ensembl domain to use for species list.",
 )
 species_map = click.option(
     "-sm",

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -190,7 +190,7 @@ class InstalledConfig:
         return self.install_path / _GENOMES_NAME
 
     def installed_genome(self, species: str) -> pathlib.Path:
-        db_name = self.species_map.get_ensembl_db_prefix(species, level="raise")
+        db_name = self.species_map.get_genome_name(species, level="raise")
         return self.genomes_path / db_name
 
     def list_genomes(self) -> list[str]:

--- a/src/ensembl_tui/_config.py
+++ b/src/ensembl_tui/_config.py
@@ -389,11 +389,12 @@ def _validate_and_resolve_domain(remote_section: dict[str, str]) -> tuple[str, s
         domain = domain_value or host_value
     else:
         domain = domain_value
-    # Validate domain exists in site map registry
-    available = eti_site_map.get_site_map_names()
-    if domain not in available:
-        msg = f"Invalid domain '{domain}'. Available domains: {', '.join(sorted(available))}"
-        raise ValueError(msg)
+
+    try:
+        site_map = eti_site_map.get_site_map(domain)
+    except KeyError as err:
+        msg = f"Invalid domain '{domain}'. Available domains: {', '.join(sorted(eti_site_map.get_site_map_names()))}"
+        raise ValueError(msg) from err
 
     # Resolve the actual FTP host from the site map
     site_map = eti_site_map.get_site_map(domain)

--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -151,11 +151,13 @@ def download_species(
             description=msg,
         )
 
-    for key in config.species_dbs:
-        db_prefix = config.species_map.get_ensembl_db_prefix(key)
-        if "collection" in db_prefix:
+    for genome_name in config.species_dbs:
+        abbrev = config.species_map.get_abbreviation(genome_name)
+        db_prefix = config.species_map.get_ensembl_db_prefix(genome_name)
+        if genome_name != db_prefix:
+            # genome in a collection
             collection_name = db_prefix
-            local_root = config.staging_genomes / key
+            local_root = config.staging_genomes / genome_name
         else:
             collection_name = None
             local_root = config.staging_genomes / db_prefix
@@ -163,7 +165,7 @@ def download_species(
         local_root.mkdir(parents=True, exist_ok=True)
 
         # getting genome sequences
-        remote = site_map.get_seqs_path(key, collection_name=collection_name)
+        remote = site_map.get_seqs_path(genome_name, collection_name=collection_name)
         remote_dir = remote_template.format(remote)
         remote_paths = list(
             eti_ftp.listdir(site_map.site, path=remote_dir, pattern=valid_seq_file),
@@ -187,7 +189,7 @@ def download_species(
             host=site_map.site,
             local_dest=dest_path,
             remote_paths=remote_paths,
-            description=f"{key[:10]}... {icon}",
+            description=f"{abbrev} {icon}",
             do_checksum=True,
             progress=progress,
         )
@@ -206,7 +208,7 @@ def download_species(
             host=site_map.site,
             local_dest=dest_path,
             remote_paths=remote_paths,
-            description=f"{db_prefix[:10]}... {icon}",
+            description=f"{abbrev} {icon}",
             do_checksum=True,
             progress=progress,
         )
@@ -311,8 +313,15 @@ def download_homology(
             description=msg,
         )
 
-    for db_name in config.db_names:
-        remote_path = remote_template.format(db_name)
+    for genome_name in config.species_dbs:
+        abbrev = config.species_map.get_abbreviation(genome_name)
+        db_name = config.species_map.get_ensembl_db_prefix(genome_name)
+        if db_name == genome_name:
+            remote_path = remote_template.format(genome_name)
+        else:
+            # genome is in a collection
+            remote_path = remote_template.format(f"{db_name}/{genome_name}")
+
         remote_paths = list(
             eti_ftp.listdir(site_map.site, remote_path, valid_compara_homology()),
         )
@@ -324,14 +333,14 @@ def download_homology(
             remote_paths = [p for p in remote_paths if not eti_util.is_signature(p)]
             remote_paths = remote_paths[:4]
 
-        local_dir = local / db_name
+        local_dir = local / genome_name
         local_dir.mkdir(parents=True, exist_ok=True)
         _remove_tmpdirs(local_dir)
         eti_ftp.download_data(
             host=site_map.site,
             local_dest=local_dir,
             remote_paths=remote_paths,
-            description=f"{db_name[:10]}...",
+            description=f"{abbrev}",
             do_checksum=False,  # no checksums for species homology files
             progress=progress,
         )

--- a/src/ensembl_tui/_ingest_align.py
+++ b/src/ensembl_tui/_ingest_align.py
@@ -103,7 +103,7 @@ def install_alignment(
 
     dest_dir.mkdir(parents=True, exist_ok=True)
     paths = list(src_dir.glob(f"{align_name}*maf*"))
-    aln_loader = load_align_records(set(config.db_names))
+    aln_loader = load_align_records(set(config.species_dbs))
     agg = make_alignment_aggregator_db()
     records = []
     series = eti_util.get_iterable_tasks(

--- a/src/ensembl_tui/_install.py
+++ b/src/ensembl_tui/_install.py
@@ -135,7 +135,7 @@ def local_install_homology(
     config.install_homologies.mkdir(parents=True, exist_ok=True)
 
     dirnames = []
-    for sp in config.db_names:
+    for sp in config.species_dbs:
         path = config.staging_homologies / sp
         dirnames.extend(list(path.glob("*.tsv*")))
 
@@ -145,7 +145,7 @@ def local_install_homology(
         eti_util.print_colour(f"homologies {max_workers=}", "yellow")
 
     loader = homology_ingest.load_homologies(
-        allowed_species=set(config.db_names),
+        allowed_species=set(config.species_dbs),
     )
     if progress is not None:
         msg = "Loading homologies"

--- a/src/ensembl_tui/_site_map.py
+++ b/src/ensembl_tui/_site_map.py
@@ -133,9 +133,6 @@ def ensembl_protists_sitemap() -> SiteMap:
     )
 
 
-# _homologies_path = "pan_ensembl/tsv/ensembl-compara/homologies",
-
-
 @cache
 def get_site_map(domain: str) -> SiteMap:
     """Returns a site map instance for the specified domain.
@@ -161,4 +158,4 @@ def get_site_map(domain: str) -> SiteMap:
 
 def get_site_map_names() -> list[str]:
     """Returns all registered Ensembl domain names."""
-    return list(_ensembl_site_map)
+    return [n for n in _ensembl_site_map if not n.startswith("ftp")]

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -48,13 +48,13 @@ def main() -> None:
 
 @main.command(**_click_command_opts)
 @cli_opt.dbrc_out
-@cli_opt.site
+@cli_opt.domain
 @cli_opt.force
-def demo_config(outpath: pathlib.Path, site: str, force_overwrite: bool) -> None:
+def demo_config(outpath: pathlib.Path, domain: str, force_overwrite: bool) -> None:
     """exports sample config and species table to the nominated path"""
     from ensembl_tui._download import download_species_table
 
-    site_map = eti_site_map.get_site_map(site)
+    site_map = eti_site_map.get_site_map(domain)
     table = download_species_table(
         site_map=site_map,
     )

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -557,7 +557,7 @@ def alignments(
 
     config = eti_config.read_installed_cfg(installed)
     align_db = eti_align.load_aligndb(config=config, align_name=align_name)
-    ref_species = config.species_map.get_ensembl_db_prefix(ref)
+    ref_species = config.species_map.get_genome_name(ref)
     if ref_species not in align_db.get_species_names():
         eti_util.print_colour(
             text=f"species {ref!r} not in the alignment",

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -17,10 +17,9 @@ def test_standard_smp():
 
 def test_get_site_map_names():
     names = eti_smap.get_site_map_names()
-    assert "ftp.ensembl.org" in names
-    assert "ftp.ensemblgenomes.org" in names
     assert "main" in names
     assert "metazoa" in names
+    assert "protists" in names
 
 
 def test_get_default_site_map_species():


### PR DESCRIPTION
## Summary by Sourcery

Handle genomes that belong to Ensembl collection databases and expose protists as a first-class domain across CLI, configuration, and site map utilities.

New Features:
- Support downloading species genomes and homology data for genomes that live inside Ensembl collection databases, including protists.
- Expose a --domain option for demo-config to select Ensembl domain (main, vertebrates, metazoa, protists) when generating sample config and species table.
- Allow passing a species map file via the download CLI using the --species_map option.

Bug Fixes:
- Fix species and homology installation logic to iterate over configured species databases instead of generic database names, ensuring correct handling of collection-based genomes.
- Correct alignment and installed genome lookups to use resolved genome names instead of raw Ensembl DB prefixes.
- Filter out low-level FTP host identifiers from the list of available site map domains and validate domains via the site map registry.

Enhancements:
- Improve download progress messages to use human-readable species abbreviations instead of truncated database names.
- Refine domain validation to raise clearer errors listing valid Ensembl domains.

Documentation:
- Update README CLI help examples to document the new --domain and --species_map options and improve formatting of option help text.

Tests:
- Adjust site map tests to assert against high-level domains (including protists) rather than raw FTP hosts.