### PR TITLE
BUG: fix progress display for installing alignments

### DIFF
--- a/src/ensembl_tui/_download.py
+++ b/src/ensembl_tui/_download.py
@@ -244,7 +244,7 @@ def download_aligns(
     msg = "Downloading alignments"
     if progress is not None:
         align_download = progress.add_task(
-            total=len(config.species_dbs),
+            total=len(config.align_names),
             description=msg,
         )
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the progress bar total for alignment downloads to use the number of alignments instead of species databases.