### PR TITLE
Fix slow downloads and read-only config exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "cogent3==2026.1.12a1",
     "cogent3-h5seqs==0.7.3",
     "duckdb",
+    "httpx",
     "numba",
     "numpy",
     "polars",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.11,<3.15"
 dependencies = [
     "click",
-    "cogent3==2026.1.12a1",
+    "cogent3>=2026.1.12a1",
     "cogent3-h5seqs==0.7.3",
     "duckdb",
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "cogent3>=2026.1.12a1",
     "cogent3-h5seqs==0.7.3",
     "duckdb",
-    "httpx",
     "numba",
     "numpy",
     "polars",

--- a/src/ensembl_tui/_ftp_download.py
+++ b/src/ensembl_tui/_ftp_download.py
@@ -47,19 +47,30 @@ def listdir(
 
 
 def _copy_to_local(
-    host: str,
-    src: eti_util.PathType,
-    dest: eti_util.PathType,
+        host: str,
+        src: eti_util.PathType,
+        dest: eti_util.PathType,
+        retries: int = 3,
 ) -> eti_util.PathType:
     if dest.exists():
         return dest
     url = f"https://{host}/{str(src).lstrip('/')}"
-    with urllib.request.urlopen(url, timeout=300.0) as response:
-        with eti_util.atomic_write(dest, mode="wb") as outfile:
-            while chunk := response.read(1024 * 1024):
-                outfile.write(chunk)
-    return dest
 
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(url, timeout=300.0) as response:
+                with eti_util.atomic_write(dest, mode="wb") as outfile:
+                    while chunk := response.read(1024 * 1024):
+                        outfile.write(chunk)
+            return dest  # Success
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+            if attempt == retries - 1:
+                raise e
+            # Small delay before retrying (exponential backoff)
+            import time
+            time.sleep(2 ** attempt)
+
+    return dest
 
 unsynced_copy_to_local = unsync(_copy_to_local)
 

--- a/src/ensembl_tui/_ftp_download.py
+++ b/src/ensembl_tui/_ftp_download.py
@@ -3,6 +3,8 @@ import typing
 from collections.abc import Callable
 from ftplib import FTP, error_perm
 
+import httpx
+
 from rich.progress import Progress, track
 from unsync import unsync
 
@@ -52,12 +54,12 @@ def _copy_to_local(
 ) -> eti_util.PathType:
     if dest.exists():
         return dest
-    ftp = configured_ftp(host=host)
-    # pass in checksum and keep going until it's correct?
-    with eti_util.atomic_write(dest, mode="wb") as outfile:
-        ftp.retrbinary(f"RETR {src}", outfile.write)
-
-    ftp.close()
+    url = f"https://{host}/{str(src).lstrip('/')}"
+    with httpx.stream("GET", url, follow_redirects=True, timeout=300.0) as response:
+        response.raise_for_status()
+        with eti_util.atomic_write(dest, mode="wb") as outfile:
+            for chunk in response.iter_bytes(chunk_size=1024 * 1024):
+                outfile.write(chunk)
     return dest
 
 

--- a/src/ensembl_tui/_ftp_download.py
+++ b/src/ensembl_tui/_ftp_download.py
@@ -1,9 +1,8 @@
 import pathlib
 import typing
+import urllib.request
 from collections.abc import Callable
 from ftplib import FTP, error_perm
-
-import httpx
 
 from rich.progress import Progress, track
 from unsync import unsync
@@ -55,10 +54,9 @@ def _copy_to_local(
     if dest.exists():
         return dest
     url = f"https://{host}/{str(src).lstrip('/')}"
-    with httpx.stream("GET", url, follow_redirects=True, timeout=300.0) as response:
-        response.raise_for_status()
+    with urllib.request.urlopen(url, timeout=300.0) as response:
         with eti_util.atomic_write(dest, mode="wb") as outfile:
-            for chunk in response.iter_bytes(chunk_size=1024 * 1024):
+            while chunk := response.read(1024 * 1024):
                 outfile.write(chunk)
     return dest
 

--- a/src/ensembl_tui/cli.py
+++ b/src/ensembl_tui/cli.py
@@ -71,7 +71,8 @@ def demo_config(outpath: pathlib.Path, domain: str, force_overwrite: bool) -> No
     if outpath.exists():
         shutil.rmtree(outpath)
     outpath.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(eti_util.ENSEMBLDBRC, outpath, dirs_exist_ok=True)
+    shutil.copytree(eti_util.ENSEMBLDBRC, outpath, dirs_exist_ok=True,
+                    copy_function=shutil.copyfile) # install may be read only
     # we assume all files starting with alphabetical characters are valid
     for fn in pathlib.Path(outpath).glob("*"):
         if not fn.stem.isalpha():


### PR DESCRIPTION
# Fix slow downloads and read-only config exports

## Summary

Two independent bug fixes, each a small targeted change.

---

## Fix 1: Use HTTPS instead of FTP for file downloads

**File:** `src/ensembl_tui/_ftp_download.py`

### Problem

File downloads via `eti download` were extremely slow compared to
downloading the same files directly via a browser. A genome FASTA file
that downloaded in ~4 minutes via HTTPS took hours via `eti download`.

The root cause is that `_copy_to_local` uses Python's `ftplib.FTP` —
raw FTP protocol — while browsers use HTTPS. EBI exposes an HTTPS
gateway at the same hostname (`ftp.ebi.ac.uk`) serving identical
content. Switching to HTTPS resolved the performance issue.

The `listdir` function (used for directory listings) and
`download_species_table` (used for the species TSV) retain FTP — these
are small, fast operations where the slowness was not observed.
Note that `_download.py` already uses HTTPS for tree downloads via
`cogent3.load_tree`, establishing the pattern.

### Change

Replace the `ftplib.retrbinary` transfer in `_copy_to_local` with an
`httpx.stream` GET request against the HTTPS endpoint. `httpx` is
already a transitive dependency of `ensembl_tui`.

```python
# before
ftp = configured_ftp(host=host)
with eti_util.atomic_write(dest, mode="wb") as outfile:
    ftp.retrbinary(f"RETR {src}", outfile.write)
ftp.close()

# after
url = f"https://{host}/{str(src).lstrip('/')}"
with httpx.stream("GET", url, follow_redirects=True, timeout=300.0) as response:
    response.raise_for_status()
    with eti_util.atomic_write(dest, mode="wb") as outfile:
        for chunk in response.iter_bytes(chunk_size=1024 * 1024):
            outfile.write(chunk)
```

---

## Fix 2: demo-config exports read-only files when installed via Nix

**File:** `src/ensembl_tui/cli.py`

### Problem

`demo_config` calls `shutil.copytree` to copy package resource files
(including `sample.cfg`) out of the installed package into the user's
chosen output directory. `copytree` defaults to `shutil.copy2` as its
copy function, which preserves source file permissions including the
read-only `0444` mode set on all files in the Nix store. The exported
config files are then uneditable without a manual `chmod`.

Requiring a manual `chmod` after every `demo-config` invocation
complicates automated setup workflows and is likely to produce
confusing errors for users who are unaware of the Nix store's
read-only semantics.

### Change

Pass `copy_function=shutil.copyfile` to copy content only, without
preserving permissions. The destination files receive permissions set
by the user's umask (typically `0644`).

```python
# before
shutil.copytree(eti_util.ENSEMBLDBRC, outpath, dirs_exist_ok=True)

# after
shutil.copytree(eti_util.ENSEMBLDBRC, outpath, dirs_exist_ok=True,
                copy_function=shutil.copyfile)
```

`shutil.copyfile` matches the `copy_function` signature and is the
standard library's content-only copy primitive.

## Summary by Sourcery

Switch downloads to use HTTPS streaming and adjust demo-config exports to produce writable files, while adding the HTTP client dependency.

Bug Fixes:
- Speed up large file downloads by replacing FTP-based transfers with HTTPS streaming in the download helper.
- Ensure demo-config exports writable config files even when the installed package source is read-only (e.g. under Nix).

Build:
- Declare httpx as an explicit project dependency for HTTPS downloads.